### PR TITLE
Ensure the permissions of a new redis-sentinel.conf

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -136,16 +136,14 @@ class redis::sentinel (
   file {
     $config_file_orig:
       ensure  => present,
-      content => template($conf_template);
-
-    $config_file:
       owner => $service_user,
       group => $service_group,
-      mode  => $config_file_mode;
+      mode  => $config_file_mode,
+      content => template($conf_template);
   }
 
   exec {
-    "cp ${config_file_orig} ${config_file}":
+    "cp -p ${config_file_orig} ${config_file}":
       path        => '/usr/bin:/bin',
       subscribe   => File[$config_file_orig],
       notify      => Service[$service_name],

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -33,12 +33,9 @@ describe 'redis::sentinel', :type => :class do
 
     it { should contain_file('/etc/redis/redis-sentinel.conf.puppet').with(
         'ensure'  => 'present',
+        'mode'    => '0644',
+        'owner'   => 'redis',
         'content' => $expected_noparams_content
-      )
-    }
-
-    it { should contain_file('/etc/redis/redis-sentinel.conf').with(
-        'mode' => '0644'
       )
     }
 


### PR DESCRIPTION
Without these changes a from-scratch redis-sentinel.conf can be
created that is not writable by the redis user, as such the sentinel
server will exit immediately after starting.

This change ensures the permissions of the *.puppet file and then
preserves those permissions upon copy. Unfortunately the copied-to
file is hard to test in the spec files, so verification in test is
no longer available. It works properly in manual testing.