### PR TITLE
Make sentinel maninfest ensure the redis package

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -150,6 +150,10 @@ class redis::sentinel (
       refreshonly => true;
   }
 
+  package { $::redis::params::package_name:
+    ensure => $::redis::params::package_ensure,
+  }
+
   service { $service_name:
     ensure     => $::redis::params::service_ensure,
     enable     => $::redis::params::service_enable,


### PR DESCRIPTION
The sentinel service needs to make sure that the redis package has
been installed on the machine where sentinel is being run. All my
previous testing had assumed that there would be a redis server and
sentinel on the same machines. This doesn't have to be the case, so
the manifest needs to make allowances for that.