### PR TITLE
Avoid resource dependency when having both Redis Server & Sentinel

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,8 @@
 # This class installs the application.
 #
 class redis::install {
-  package { $::redis::package_name:
-    ensure => $::redis::package_ensure,
-  }
+  ensure_resource('package', $::redis::package_name, {
+    'ensure' => $::redis::package_ensure
+  })
 }
 

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -134,9 +134,9 @@ class redis::sentinel (
 ) inherits redis::params {
 
 
-  package { $::redis::params::package_name:
-    ensure => $::redis::params::package_ensure,
-  }
+  ensure_resource('package', $::redis::params::package_name, {
+    'ensure' => $::redis::params::package_ensure
+  })
 
   file {
     $config_file_orig:

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -27,6 +27,12 @@ EOF
 describe 'redis::sentinel', :type => :class do
   let (:facts) { debian_facts }
 
+  let :pre_condition do
+    [
+     'class { redis: }'
+    ]
+  end
+
   describe 'without parameters' do
 
     it { should create_class('redis::sentinel') }


### PR DESCRIPTION
When running Redis Server & Redis Sentinel on the same node, avoid a
resource dupplication with package resource.