### PR TITLE
metadata: add stdlib as a requirement

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -68,8 +68,7 @@
     }
   ],
   "dependencies": [
-    {
-      "name": "puppetlabs/apt"
-    }
+    { "name": "puppetlabs/apt" },
+    { "name": "puppetlabs/stdlib" },
   ]
 }


### PR DESCRIPTION
We are using puppet-stdlib with ensure_resource so we need to add it in
requirements.