### PR TITLE
fix trailing comma in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -69,6 +69,6 @@
   ],
   "dependencies": [
     { "name": "puppetlabs/apt" },
-    { "name": "puppetlabs/stdlib" },
+    { "name": "puppetlabs/stdlib" }
   ]
 }


### PR DESCRIPTION
Trailing commas are not allowed in the JSON spec. This
causes an error when using librarian-puppet and the
:git option.