### PR TITLE
Add an initscript for sentinel on apt-based systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -14,7 +14,6 @@ class redis::params {
   $auto_aof_rewrite_percentage = 100
   $bind                        = '127.0.0.1'
   $conf_template               = 'redis/redis.conf.erb'
-  $daemonize                   = true
   $databases                   = 16
   $dbfilename                  = 'dump.rdb'
   $extra_config_file           = undef
@@ -47,6 +46,7 @@ class redis::params {
   $sentinel_quorum             = 2
   $sentinel_service_name       = 'redis-sentinel'
   $sentinel_working_dir        = '/tmp'
+  $sentinel_init_template      = 'redis/redis-sentinel.init.erb'
   $set_max_intset_entries      = 512
   $slowlog_log_slower_than     = 10000
   $slowlog_max_len             = 1024
@@ -74,10 +74,14 @@ class redis::params {
       $config_file_mode          = '0644'
       $config_group              = 'root'
       $config_owner              = 'root'
+      $daemonize                 = true
       $package_ensure            = 'present'
       $package_name              = 'redis-server'
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $sentinel_init_script      = '/etc/init.d/redis-sentinel'
+      $sentinel_package_name     = 'redis-server'
+      $sentinel_package_ensure   = 'present'
       $service_enable            = true
       $service_ensure            = 'running'
       $service_group             = 'redis'
@@ -95,10 +99,14 @@ class redis::params {
       $config_file_mode          = '0644'
       $config_group              = 'root'
       $config_owner              = 'root'
+      $daemonize                 = false
       $package_ensure            = 'present'
       $package_name              = 'redis'
       $sentinel_config_file      = '/etc/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
+      $sentinel_init_script      = undef
+      $sentinel_package_name     = 'redis'
+      $sentinel_package_ensure   = 'present'
       $service_enable            = true
       $service_ensure            = 'running'
       $service_group             = 'redis'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -47,6 +47,7 @@ class redis::params {
   $sentinel_service_name       = 'redis-sentinel'
   $sentinel_working_dir        = '/tmp'
   $sentinel_init_template      = 'redis/redis-sentinel.init.erb'
+  $sentinel_pid_file           = '/var/run/redis/redis-sentinel.pid'
   $set_max_intset_entries      = 512
   $slowlog_log_slower_than     = 10000
   $slowlog_max_len             = 1024

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -84,6 +84,11 @@
 #
 #   Default: 1
 #
+# [*pid_file*]
+#   If sentinel is daemonized it will write its pid at this location.
+#
+#   Default: /var/run/redis/redis-sentinel.pid
+#
 # [*quorum*]
 #   Number of sentinels that must agree that a master is down to
 #   signal sdown state.
@@ -144,6 +149,7 @@ class redis::sentinel (
   $package_name      = $::redis::params::sentinel_package_name,
   $package_ensure    = $::redis::params::sentinel_package_ensure,
   $parallel_sync     = $::redis::params::sentinel_parallel_sync,
+  $pid_file          = $::redis::params::sentinel_pid_file,
   $quorum            = $::redis::params::sentinel_quorum,
   $sentinel_port     = $::redis::params::sentinel_port,
   $service_group     = $::redis::params::service_group,
@@ -184,6 +190,10 @@ class redis::sentinel (
         mode    => '0755',
         content => template($init_template),
         require => Package[$package_name];
+    }
+    exec {
+       "/usr/sbin/update-rc.d redis-sentinel defaults":
+         require => File[$init_script];
     }
   }
 

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -4,6 +4,8 @@ $expected_noparams_content = <<EOF
 port 26379
 dir /tmp
 daemonize yes
+pidfile /var/run/redis/redis-sentinel.pid
+
 sentinel monitor mymaster 127.0.0.1 6379 2
 sentinel down-after-milliseconds mymaster 30000
 sentinel parallel-syncs mymaster 1
@@ -16,6 +18,8 @@ $expected_params_content = <<EOF
 port 26379
 dir /tmp
 daemonize yes
+pidfile /var/run/redis/redis-sentinel.pid
+
 sentinel monitor cow 127.0.0.1 6379 2
 sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 $expected_noparams_content = <<EOF
 port 26379
 dir /tmp
-
+daemonize yes
 sentinel monitor mymaster 127.0.0.1 6379 2
 sentinel down-after-milliseconds mymaster 30000
 sentinel parallel-syncs mymaster 1
@@ -15,7 +15,7 @@ EOF
 $expected_params_content = <<EOF
 port 26379
 dir /tmp
-
+daemonize yes
 sentinel monitor cow 127.0.0.1 6379 2
 sentinel down-after-milliseconds cow 6000
 sentinel parallel-syncs cow 1

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -1,6 +1,7 @@
 port <%= @sentinel_port %>
 dir <%= @working_dir %>
-<% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end -%>
+<% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end %>
+pidfile <%= @pid_file %>
 
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -1,5 +1,6 @@
 port <%= @sentinel_port %>
 dir <%= @working_dir %>
+<% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end -%>
 
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>

--- a/templates/redis-sentinel.init.erb
+++ b/templates/redis-sentinel.init.erb
@@ -1,0 +1,89 @@
+#! /bin/sh
+### BEGIN INIT INFO
+# Provides:		redis-sentinel
+# Required-Start:	$syslog $remote_fs
+# Required-Stop:	$syslog $remote_fs
+# Should-Start:		$local_fs
+# Should-Stop:		$local_fs
+# Default-Start:	2 3 4 5
+# Default-Stop:		0 1 6
+# Short-Description:	redis-server - Persistent key-value db
+# Description:		redis-server - Persistent key-value db
+### END INIT INFO
+
+
+PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+DAEMON=/usr/bin/redis-sentinel
+DAEMON_ARGS=<%= @config_file %>
+NAME=redis-sentinel
+DESC=redis-senitnel
+
+RUNDIR=/var/run/redis
+PIDFILE=$RUNDIR/redis-sentinel.pid
+
+test -x $DAEMON || exit 0
+
+if [ -r /etc/default/$NAME ]
+then
+	. /etc/default/$NAME
+fi
+
+. /lib/lsb/init-functions
+
+set -e
+
+case "$1" in
+  start)
+	echo -n "Starting $DESC: "
+	mkdir -p $RUNDIR
+	touch $PIDFILE
+	chown <%= @service_user %>:<%= @service_group %> $RUNDIR $PIDFILE
+	chmod 755 $RUNDIR
+
+	if [ -n "$ULIMIT" ]
+	then
+		ulimit -n $ULIMIT
+	fi
+
+	if start-stop-daemon --start --quiet --umask 007 --pidfile $PIDFILE --chuid <%= @service_user %>:<%= @service_group %> --exec $DAEMON -- $DAEMON_ARGS
+	then
+		echo "$NAME."
+	else
+		echo "failed"
+	fi
+	;;
+  stop)
+	echo -n "Stopping $DESC: "
+	if start-stop-daemon --stop --retry forever/TERM/1 --quiet --oknodo --pidfile $PIDFILE --exec $DAEMON
+	then
+		echo "$NAME."
+	else
+		echo "failed"
+	fi
+	rm -f $PIDFILE
+	sleep 1
+	;;
+
+  restart|force-reload)
+	${0} stop
+	${0} start
+	;;
+
+  status)
+	echo -n "$DESC is "
+	if start-stop-daemon --stop --quiet --signal 0 --name ${NAME} --pidfile ${PIDFILE}
+	then
+		echo "running"
+	else
+		echo "not running"
+		exit 1
+	fi
+	;;
+
+  *)
+	echo "Usage: /etc/init.d/$NAME {start|stop|restart|force-reload|status}" >&2
+	exit 1
+	;;
+esac
+
+exit 0

--- a/templates/redis-sentinel.init.erb
+++ b/templates/redis-sentinel.init.erb
@@ -7,8 +7,8 @@
 # Should-Stop:		$local_fs
 # Default-Start:	2 3 4 5
 # Default-Stop:		0 1 6
-# Short-Description:	redis-server - Persistent key-value db
-# Description:		redis-server - Persistent key-value db
+# Short-Description:	redis-sentinel - Monitor redis-server
+# Description:		redis-sentinel - Monitor redis-server
 ### END INIT INFO
 
 


### PR DESCRIPTION
Until an initscript is available for redis-sentinel in its package[1]
we need to roll our own. This change adds that by creating a templated
initscript with the sentinel config file and service owner and group
as template variables that get filled in.

Testing this revealed some bugs and misfeatures that are also addressed
in this change:

* apt systems want the redis and redis-sentinel processes to daemonize
  (systemd-based) rpm does not. This was not reflected in the params
  defaults, nor reflected in the sentinel configuration template. Now
  it is.

* the package_name for redis-sentinel was not being passed in as a
  parameter, instead it was just using the params.pp default for
  redis server. When [1] is resolve, it will likely mean a different
  package for redis-sentinel so we need there to be a separate parameter
  for the sentinel package that gets installed. For now the name of
  the existing package is used.

[1] https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775414