### PR TITLE
redis::config inherits redis

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -2,7 +2,7 @@
 #
 # This class provides configuration for Redis.
 #
-class redis::config {
+class redis::config inherits redis {
   if $::redis::notify_service {
     File {
       owner  => $::redis::config_owner,

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -13,7 +13,8 @@ describe 'redis', :type => :class do
     it { should contain_package('redis-server').with_ensure('present') }
 
     it { should contain_file('/etc/redis/redis.conf').with(
-        'ensure' => 'present'
+        'ensure'  => 'present',
+        'content' => /port 6379/
       )
     }
 


### PR DESCRIPTION
This allows the template variables to be scoped locally.  Also
amended the test to look for the default port number in the
config file template output.

With no parameters, on Ubuntu 12, the redis.conf file was coming up with no parameters.