### PR TITLE
adding anchors to make the ensure_resource behaive

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -417,21 +417,29 @@ class redis (
   $zset_max_ziplist_entries    = $::redis::params::zset_max_ziplist_entries,
   $zset_max_ziplist_value      = $::redis::params::zset_max_ziplist_value,
 ) inherits redis::params {
+
+  anchor { 'redis::begin': }
+  anchor { 'redis::end': }
+
   include redis::preinstall
   include redis::install
   include redis::config
   include redis::service
 
   if $::redis::notify_service {
+    Anchor['redis::begin'] ->
     Class['redis::preinstall'] ->
     Class['redis::install'] ->
     Class['redis::config'] ~>
-    Class['redis::service']
+    Class['redis::service'] ->
+    Anchor['redis::end']
   } else {
+    Anchor['redis::begin'] ->
     Class['redis::preinstall'] ->
     Class['redis::install'] ->
     Class['redis::config'] ->
-    Class['redis::service']
+    Class['redis::service'] ->
+    Anchor['redis::end']
   }
 
   # Sanity check
@@ -440,5 +448,5 @@ class redis (
       fail "Replication is not possible when binding to ${::redis::bind}."
     }
   }
-}
 
+}


### PR DESCRIPTION
Adding anchors to contain the resources within the redis module. I posted on the puppet mailing list about [this issue](https://groups.google.com/forum/#!topic/puppet-users/OnA-lI2clD4).

Happy to do a different solution if you don't like anchors.

-Shawn