### PR TITLE
added Suse osfamily

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -146,6 +146,31 @@ class redis::params {
       $service_user              = 'redis'
     }
 
+    'Suse': {
+      $config_dir                = '/etc/redis'
+      $config_dir_mode           = '0750'
+      $config_file               = '/etc/redis/redis.conf'
+      $config_file_mode          = '0644'
+      $config_group              = 'redis'
+      $config_owner              = 'redis'
+      $daemonize                 = true
+      $log_dir_mode              = '0750'
+      $package_ensure            = 'present'
+      $package_name              = 'redis'
+      $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
+      $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $sentinel_init_script      = undef
+      $sentinel_package_name     = 'redis'
+      $sentinel_package_ensure   = 'present'
+      $service_enable            = true
+      $service_ensure            = 'running'
+      $service_group             = 'redis'
+      $service_hasrestart        = true
+      $service_hasstatus         = true
+      $service_name              = 'redis'
+      $service_user              = 'redis'
+    }
+
     default: {
       fail "Operating system ${::operatingsystem} is not supported yet."
     }


### PR DESCRIPTION
tested on sles11sp3 with redis for server, sentinel untested
used redis rpm from suse (http://software.opensuse.org/download.html?project=server:database&package=redis)