### PR TITLE
Enable to not manage the Redis service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -234,6 +234,11 @@
 #
 #   Default: undef
 #
+# [*service_manage*]
+#   Specify if the service should be part of the catalog.
+#
+#   Default: true
+#
 # [*service_enable*]
 #   Enable/disable daemon at boot.
 #
@@ -402,6 +407,7 @@ class redis (
   $repl_ping_slave_period      = $::redis::params::repl_ping_slave_period,
   $repl_timeout                = $::redis::params::repl_timeout,
   $requirepass                 = $::redis::params::requirepass,
+  $service_manage              = $::redis::params::service_manage,
   $service_enable              = $::redis::params::service_enable,
   $service_ensure              = $::redis::params::service_ensure,
   $service_group               = $::redis::params::service_group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -86,6 +86,7 @@ class redis::params {
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-server'
       $sentinel_package_ensure   = 'present'
+      $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
       $service_group             = 'redis'
@@ -112,6 +113,7 @@ class redis::params {
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
+      $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
       $service_group             = 'redis'
@@ -137,6 +139,7 @@ class redis::params {
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
+      $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
       $service_group             = 'redis'
@@ -162,6 +165,7 @@ class redis::params {
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
+      $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
       $service_group             = 'redis'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,11 +3,13 @@
 # This class manages the Redis daemon.
 #
 class redis::service {
-  service { $::redis::service_name:
-    ensure     => $::redis::service_ensure,
-    enable     => $::redis::service_enable,
-    hasrestart => $::redis::service_hasrestart,
-    hasstatus  => $::redis::service_hasstatus,
+  if $::redis::service_manage {
+    service { $::redis::service_name:
+      ensure     => $::redis::service_ensure,
+      enable     => $::redis::service_enable,
+      hasrestart => $::redis::service_hasrestart,
+      hasstatus  => $::redis::service_hasstatus,
+    }
   }
 }
 

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -502,6 +502,12 @@ describe 'redis', :type => :class do
     }
   end
 
+  describe 'with parameter: service_manage (set to false)' do
+    let (:params) { { :service_manage => false } }
+
+    it { should_not contain_service('redis-server') }
+  end
+
   describe 'with parameter: service_enable' do
     let (:params) { { :service_enable => true } }
 


### PR DESCRIPTION
In some system setup, we do not want Puppet to handle the service but
another system (ie. Pacemaker), for this reason, the service should not
be part of the catalog at all, hence the creation of this boolean.

It has to be used in conjunction of `$notify_file = false` to not depend
of the Service resource.