### PR TITLE
fix issue with params.pp with strict_variables enabled

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -121,6 +121,7 @@ class redis::params {
       $service_hasstatus         = true
       $service_name              = 'redis'
       $service_user              = 'redis'
+      $ppa_repo                  = undef
     }
 
     'FreeBSD': {
@@ -147,6 +148,7 @@ class redis::params {
       $service_hasstatus         = true
       $service_name              = 'redis'
       $service_user              = 'redis'
+      $ppa_repo                  = undef
     }
 
     'Suse': {
@@ -173,6 +175,7 @@ class redis::params {
       $service_hasstatus         = true
       $service_name              = 'redis'
       $service_user              = 'redis'
+      $ppa_repo                  = undef
     }
 
     default: {


### PR DESCRIPTION
When strict_variables are enabled Puppet runs fail with Evaluation Error: Unknown variable: '::redis::params::ppa_repo'. 

This happens when the osfamily fact is set to anything but Debian because the ppa_repo variable is not defined and is referenced in init.pp parameters.

Defining the variable under the other osfamilys and setting it to undef fixes the issue.

https://docs.puppetlabs.com/references/latest/configuration.html#strictvariables

