### PR TITLE
Fixed duplicate declaration of package

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,8 +3,10 @@
 # This class installs the application.
 #
 class redis::install {
-  ensure_resource('package', $::redis::package_name, {
-    'ensure' => $::redis::package_ensure
-  })
+  unless defined(Package["$::redis::package_name"]) {
+    ensure_resource('package', $::redis::package_name, {
+      'ensure' => $::redis::package_ensure
+    })
+  }
 }
 

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -170,10 +170,11 @@ class redis::sentinel (
   $notification_script = $::redis::params::sentinel_notification_script,
 ) inherits redis::params {
 
-
-  ensure_resource('package', $package_name, {
-    'ensure' => $package_ensure
-  })
+  unless defined(Package["$package_name"]) {
+    ensure_resource('package', $package_name, {
+      'ensure' => $package_ensure
+    })
+  }
 
   file {
     $config_file_orig:


### PR DESCRIPTION
Added `unless defined` statement to avoid the duplicate declaration of package if both `redis` and `redis::sentinel` classes applied on same node.