### PR TITLE
access out-of-scope variables via the scope.lookupvar method

### DIFF
--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -1,6 +1,6 @@
 port <%= @sentinel_port %>
 dir <%= @working_dir %>
-<% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end %>
+<% if scope.lookupvar('::redis::daemonize') -%>daemonize yes<% else -%>daemonize no<% end %>
 pidfile <%= @pid_file %>
 
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -14,20 +14,20 @@
 
 # By default Redis does not run as a daemon. Use 'yes' if you need it.
 # Note that Redis will write a pid file in /var/run/redis.pid when daemonized.
-<% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end -%>
+<% if scope.lookupvar('::redis::daemonize') -%>daemonize yes<% else -%>daemonize no<% end -%>
 
 # When running daemonized, Redis writes a pid file in /var/run/redis.pid by
 # default. You can specify a custom pid file location here.
-pidfile <%= @pid_file %>
+pidfile <%= scope.lookupvar('::redis::pid_file') %>
 
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.
-port <%= @port %>
+port <%= scope.lookupvar('::redis::port') %>
 
 # If you want you can bind a single interface, if the bind option is not
 # specified all the interfaces will listen for incoming connections.
 #
-bind <%= @bind %>
+bind <%= scope.lookupvar('::redis::bind') %>
 
 # Specify the path for the unix socket that will be used to listen for
 # incoming connections. There is no default, so Redis will not listen
@@ -37,7 +37,7 @@ bind <%= @bind %>
 # unixsocketperm 755
 
 # Close the connection after a client is idle for N seconds (0 to disable)
-timeout <%= @timeout %>
+timeout <%= scope.lookupvar('::redis::timeout') %>
 
 # Set server verbosity to 'debug'
 # it can be one of:
@@ -45,27 +45,27 @@ timeout <%= @timeout %>
 # verbose (many rarely useful info, but not a mess like the debug level)
 # notice (moderately verbose, what you want in production probably)
 # warning (only very important / critical messages are logged)
-loglevel <%= @log_level %>
+loglevel <%= scope.lookupvar('::redis::log_level') %>
 
 # Specify the log file name. Also 'stdout' can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile <%= @log_file %>
+logfile <%= scope.lookupvar('::redis::log_file') %>
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.
-<% if @syslog_enabled %>syslog-enabled yes<% else %>syslog-enabled no<% end %>
+<% if scope.lookupvar('::redis::syslog_enabled') %>syslog-enabled yes<% else %>syslog-enabled no<% end %>
 
 # Specify the syslog identity.
 # syslog-ident redis
 
 # Specify the syslog facility.  Must be USER or between LOCAL0-LOCAL7.
-<% if @syslog_facility %>syslog-facility <%= @syslog_facility %><% else %># syslog-facility local0<% end %>
+<% if scope.lookupvar('::redis::syslog_facility') %>syslog-facility <%= scope.lookupvar('::redis::syslog_facility') %><% else %># syslog-facility local0<% end %>
 
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where
 # dbid is a number between 0 and 'databases'-1
-databases <%= @databases %>
+databases <%= scope.lookupvar('::redis::databases') %>
 
 ################################ SNAPSHOTTING  #################################
 #
@@ -112,7 +112,7 @@ stop-writes-on-bgsave-error yes
 # For default that's set to 'yes' as it's almost always a win.
 # If you want to save some CPU in the saving child set it to 'no' but
 # the dataset will likely be bigger if you have compressible values or keys.
-<% if @rdbcompression -%>rdbcompression yes<% else -%>rdbcompression no<% end -%>
+<% if scope.lookupvar('::redis::rdbcompression') -%>rdbcompression yes<% else -%>rdbcompression no<% end -%>
 
 # Since verison 5 of RDB a CRC64 checksum is placed at the end of the file.
 # This makes the format more resistant to corruption but there is a performance
@@ -124,7 +124,7 @@ stop-writes-on-bgsave-error yes
 rdbchecksum yes
 
 # The filename where to dump the DB
-dbfilename <%= @dbfilename %>
+dbfilename <%= scope.lookupvar('::redis::dbfilename') %>
 
 # The working directory.
 #
@@ -134,7 +134,7 @@ dbfilename <%= @dbfilename %>
 # Also the Append Only File will be created inside this directory.
 #
 # Note that you must specify a directory here, not a file name.
-dir <%= @workdir %>
+dir <%= scope.lookupvar('::redis::workdir') %>
 
 ################################# REPLICATION #################################
 
@@ -144,7 +144,7 @@ dir <%= @workdir %>
 # different interval, or to listen to another port, and so on.
 #
 # slaveof <masterip> <masterport>
-<% if @slaveof -%>slaveof <%= @slaveof %><% end -%>
+<% if scope.lookupvar('::redis::slaveof') -%>slaveof <%= scope.lookupvar('::redis::slaveof') %><% end -%>
 
 # If the master is password protected (using the "requirepass" configuration
 # directive below) it is possible to tell the slave to authenticate before
@@ -152,7 +152,7 @@ dir <%= @workdir %>
 # refuse the slave request.
 #
 # masterauth <master-password>
-<% if @masterauth -%>masterauth <%= @masterauth %><% end -%>
+<% if scope.lookupvar('::redis::masterauth') -%>masterauth <%= scope.lookupvar('::redis::masterauth') %><% end -%>
 
 # When a slave lost the connection with the master, or when the replication
 # is still in progress, the slave can act in two different ways:
@@ -165,7 +165,7 @@ dir <%= @workdir %>
 #    an error "SYNC with master in progress" to all the kind of commands
 #    but to INFO and SLAVEOF.
 #
-slave-serve-stale-data <% if @slave_serve_stale_data -%>yes<% else -%>no<% end -%>
+slave-serve-stale-data <% if scope.lookupvar('::redis::slave_serve_stale_data') -%>yes<% else -%>no<% end -%>
 
 # You can configure a slave instance to accept writes or not. Writing against
 # a slave instance may be useful to store some ephemeral data (because data
@@ -181,7 +181,7 @@ slave-serve-stale-data <% if @slave_serve_stale_data -%>yes<% else -%>no<% end -
 # such as CONFIG, DEBUG, and so forth. To a limited extend you can improve
 # security of read only slaves using 'rename-command' to shadow all the
 # administrative / dangerous commands.
-slave-read-only <% if @slave_read_only -%>yes<% else -%>no<% end -%>
+slave-read-only <% if scope.lookupvar('::redis::slave_read_only') -%>yes<% else -%>no<% end -%>
 
 # Slaves send PINGs to server in a predefined interval. It's possible to change
 # this interval with the repl_ping_slave_period option. The default value is 10
@@ -196,7 +196,7 @@ slave-read-only <% if @slave_read_only -%>yes<% else -%>no<% end -%>
 # specified for repl-ping-slave-period otherwise a timeout will be detected
 # every time there is low traffic between the master and the slave.
 #
-repl-timeout <%= @repl_timeout %>
+repl-timeout <%= scope.lookupvar('::redis::repl_timeout') %>
 
 # The slave priority is an integer number published by Redis in the INFO output.
 # It is used by Redis Sentinel in order to select a slave to promote into a
@@ -226,7 +226,7 @@ slave-priority 100
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
 #
-<% if @requirepass -%>requirepass <%= @requirepass %><% end -%>
+<% if scope.lookupvar('::redis::requirepass') -%>requirepass <%= scope.lookupvar('::redis::requirepass') %><% end -%>
 
 # Command renaming.
 #
@@ -255,7 +255,7 @@ slave-priority 100
 # Once the limit is reached Redis will close all the new connections sending
 # an error 'max number of clients reached'.
 #
-maxclients <%= @maxclients %>
+maxclients <%= scope.lookupvar('::redis::maxclients') %>
 
 # Don't use more memory than the specified amount of bytes.
 # When the memory limit is reached Redis will try to remove keys
@@ -281,7 +281,7 @@ maxclients <%= @maxclients %>
 # output buffers (but this is not needed if the policy is 'noeviction').
 #
 # maxmemory <bytes>
-<% if @maxmemory -%>maxmemory <%= @maxmemory %><% end -%>
+<% if scope.lookupvar('::redis::maxmemory') -%>maxmemory <%= scope.lookupvar('::redis::maxmemory') %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:
@@ -305,7 +305,7 @@ maxclients <%= @maxclients %>
 # The default is:
 #
 # maxmemory-policy volatile-lru
-<% if @maxmemory_policy -%>maxmemory-policy <%= @maxmemory_policy %><% end -%>
+<% if scope.lookupvar('::redis::maxmemory_policy') -%>maxmemory-policy <%= scope.lookupvar('::redis::maxmemory_policy') %><% end -%>
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can select as well the sample
@@ -314,7 +314,7 @@ maxclients <%= @maxclients %>
 # using the following configuration directive.
 #
 # maxmemory-samples 3
-<% if @maxmemory_samples -%>maxmemory-samples <%= @maxmemory_samples %><% end -%>
+<% if scope.lookupvar('::redis::maxmemory_samples') -%>maxmemory-samples <%= scope.lookupvar('::redis::maxmemory_samples') %><% end -%>
 
 ############################## APPEND ONLY MODE ###############################
 
@@ -336,7 +336,7 @@ maxclients <%= @maxclients %>
 #
 # Please check http://redis.io/topics/persistence for more information.
 
-<% if @appendonly -%>appendonly yes<% else -%>appendonly no<% end -%>
+<% if scope.lookupvar('::redis::appendonly') -%>appendonly yes<% else -%>appendonly no<% end -%>
 
 # The name of the append only file (default: "appendonly.aof")
 # appendfilename appendonly.aof
@@ -364,7 +364,7 @@ maxclients <%= @maxclients %>
 #
 # If unsure, use "everysec".
 
-appendfsync <%= @appendfsync %>
+appendfsync <%= scope.lookupvar('::redis::appendfsync') %>
 
 # When the AOF fsync policy is set to always or everysec, and a background
 # saving process (a background save or AOF log background rewriting) is
@@ -384,7 +384,7 @@ appendfsync <%= @appendfsync %>
 #
 # If you have latency problems turn this to "yes". Otherwise leave it as
 # "no" that is the safest pick from the point of view of durability.
-<% if @no_appendfsync_on_rewrite -%>no-appendfsync-on-rewrite yes<% else -%>no-appendfsync-on-rewrite no<% end -%>
+<% if scope.lookupvar('::redis::no_appendfsync_on_rewrite') -%>no-appendfsync-on-rewrite yes<% else -%>no-appendfsync-on-rewrite no<% end -%>
 
 # Automatic rewrite of the append only file.
 # Redis is able to automatically rewrite the log file implicitly calling
@@ -403,8 +403,8 @@ appendfsync <%= @appendfsync %>
 # Specify a percentage of zero in order to disable the automatic AOF
 # rewrite feature.
 
-auto-aof-rewrite-percentage <%= @auto_aof_rewrite_percentage %>
-auto-aof-rewrite-min-size   <%= @auto_aof_rewrite_min_size %>
+auto-aof-rewrite-percentage <%= scope.lookupvar('::redis::auto_aof_rewrite_percentage') %>
+auto-aof-rewrite-min-size   <%= scope.lookupvar('::redis::auto_aof_rewrite_min_size') %>
 
 ################################ LUA SCRIPTING  ###############################
 
@@ -442,38 +442,38 @@ lua-time-limit 5000
 # The following time is expressed in microseconds, so 1000000 is equivalent
 # to one second. Note that a negative number disables the slow log, while
 # a value of zero forces the logging of every command.
-slowlog-log-slower-than <%= @slowlog_log_slower_than %>
+slowlog-log-slower-than <%= scope.lookupvar('::redis::slowlog_log_slower_than') %>
 
 # There is no limit to this length. Just be aware that it will consume memory.
 # You can reclaim memory used by the slow log with SLOWLOG RESET.
-slowlog-max-len <%= @slowlog_max_len %>
+slowlog-max-len <%= scope.lookupvar('::redis::slowlog_max_len') %>
 
 ############################### ADVANCED CONFIG ###############################
 
 # Hashes are encoded using a memory efficient data structure when they have a
 # small number of entries, and the biggest entry does not exceed a given
 # threshold. These thresholds can be configured using the following directives.
-hash-max-ziplist-entries <%= @hash_max_ziplist_entries %>
-hash-max-ziplist-value <%= @hash_max_ziplist_value %>
+hash-max-ziplist-entries <%= scope.lookupvar('::redis::hash_max_ziplist_entries') %>
+hash-max-ziplist-value <%= scope.lookupvar('::redis::hash_max_ziplist_value') %>
 
 # Similarly to hashes, small lists are also encoded in a special way in order
 # to save a lot of space. The special representation is only used when
 # you are under the following limits:
-list-max-ziplist-entries <%= @list_max_ziplist_entries %>
-list-max-ziplist-value <%= @list_max_ziplist_value %>
+list-max-ziplist-entries <%= scope.lookupvar('::redis::list_max_ziplist_entries') %>
+list-max-ziplist-value <%= scope.lookupvar('::redis::list_max_ziplist_value') %>
 
 # Sets have a special encoding in just one case: when a set is composed
 # of just strings that happens to be integers in radix 10 in the range
 # of 64 bit signed integers.
 # The following configuration setting sets the limit in the size of the
 # set in order to use this special memory saving encoding.
-set-max-intset-entries <%= @set_max_intset_entries %>
+set-max-intset-entries <%= scope.lookupvar('::redis::set_max_intset_entries') %>
 
 # Similarly to hashes and lists, sorted sets are also specially encoded in
 # order to save a lot of space. This encoding is only used when the length and
 # elements of a sorted set are below the following limits:
-zset-max-ziplist-entries <%= @zset_max_ziplist_entries %>
-zset-max-ziplist-value <%= @zset_max_ziplist_value %>
+zset-max-ziplist-entries <%= scope.lookupvar('::redis::zset_max_ziplist_entries') %>
+zset-max-ziplist-value <%= scope.lookupvar('::redis::zset_max_ziplist_value') %>
 
 # Active rehashing uses 1 millisecond every 100 milliseconds of CPU time in
 # order to help rehashing the main Redis hash table (the one mapping top-level
@@ -493,7 +493,7 @@ zset-max-ziplist-value <%= @zset_max_ziplist_value %>
 #
 # use "activerehashing yes" if you don't have such hard requirements but
 # want to free memory asap when possible.
-<% if @activerehashing -%>activerehashing yes<% else -%>activerehashing no<% end -%>
+<% if scope.lookupvar('::redis::activerehashing') -%>activerehashing yes<% else -%>activerehashing no<% end -%>
 
 # The client output buffer limits can be used to force disconnection of clients
 # that are not reading data from the server fast enough for some reason (a
@@ -541,7 +541,7 @@ client-output-buffer-limit pubsub 32mb 8mb 60
 #
 # include /path/to/local.conf
 # include /path/to/other.conf
-<% if @extra_config_file -%>
-include <%= @extra_config_file %>
+<% if scope.lookupvar('::redis::extra_config_file') -%>
+include <%= scope.lookupvar('::redis::extra_config_file') %>
 <% end -%>
 


### PR DESCRIPTION
The templates/redis-sentinel.conf.erb and templates/redis.conf.erb are accessing out-of-scope variables by accessing variables declared top level redis class.

In Puppet 4 and Puppet 3 with Future Parser enabled the values of these variables are blank in the resulting configuration files.

Puppet 4 and Puppet 3 with Future Parser enabled no longer supports relative namespace lookups.
https://tickets.puppetlabs.com/browse/PUP-121

You must access these variables by calling the scope.lookupvar function with the fully qualified variable name as the argument. This PR modifies the 2 templates to use the scope.lookupvar function.