### PR TITLE
Params set to undef are being included in the redis.conf file as a literal 'undef'

### DIFF
--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -7,10 +7,10 @@ sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>
 sentinel parallel-syncs <%= @master_name %> <%= @parallel_sync %>
 sentinel failover-timeout <%= @master_name %> <%= @failover_timeout %>
-<% if @auth_pass -%>
+<% if defined? @auth_pass -%>
 sentinel auth-pass <%= @master_name %> <%= @auth_pass %>
 <% end -%>
-<% if @notification_script -%>
+<% if defined? @notification_script -%>
 sentinel notification-script <%= @master_name %> <%= @notification_script %>
 <% end -%>
 

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -60,7 +60,7 @@ logfile <%= @log_file %>
 # syslog-ident redis
 
 # Specify the syslog facility.  Must be USER or between LOCAL0-LOCAL7.
-<% if @syslog_facility %>syslog-facility <%= @syslog_facility %><% else %># syslog-facility local0<% end %>
+<% if defined? @syslog_facility %>syslog-facility <%= @syslog_facility %><% else %># syslog-facility local0<% end %>
 
 # Set the number of databases. The default database is DB 0, you can select
 # a different one on a per-connection basis using SELECT <dbid> where
@@ -144,7 +144,7 @@ dir <%= @workdir %>
 # different interval, or to listen to another port, and so on.
 #
 # slaveof <masterip> <masterport>
-<% if @slaveof -%>slaveof <%= @slaveof %><% end -%>
+<% if defined? @slaveof -%>slaveof <%= @slaveof %><% end -%>
 
 # If the master is password protected (using the "requirepass" configuration
 # directive below) it is possible to tell the slave to authenticate before
@@ -152,7 +152,7 @@ dir <%= @workdir %>
 # refuse the slave request.
 #
 # masterauth <master-password>
-<% if @masterauth -%>masterauth <%= @masterauth %><% end -%>
+<% if defined? @masterauth -%>masterauth <%= @masterauth %><% end -%>
 
 # When a slave lost the connection with the master, or when the replication
 # is still in progress, the slave can act in two different ways:
@@ -226,7 +226,7 @@ slave-priority 100
 # 150k passwords per second against a good box. This means that you should
 # use a very strong password otherwise it will be very easy to break.
 #
-<% if @requirepass -%>requirepass <%= @requirepass %><% end -%>
+<% if defined? @requirepass -%>requirepass <%= @requirepass %><% end -%>
 
 # Command renaming.
 #
@@ -281,7 +281,7 @@ maxclients <%= @maxclients %>
 # output buffers (but this is not needed if the policy is 'noeviction').
 #
 # maxmemory <bytes>
-<% if @maxmemory -%>maxmemory <%= @maxmemory %><% end -%>
+<% if defined? @maxmemory -%>maxmemory <%= @maxmemory %><% end -%>
 
 # MAXMEMORY POLICY: how Redis will select what to remove when maxmemory
 # is reached? You can select among five behavior:
@@ -305,7 +305,7 @@ maxclients <%= @maxclients %>
 # The default is:
 #
 # maxmemory-policy volatile-lru
-<% if @maxmemory_policy -%>maxmemory-policy <%= @maxmemory_policy %><% end -%>
+<% if defined? @maxmemory_policy -%>maxmemory-policy <%= @maxmemory_policy %><% end -%>
 
 # LRU and minimal TTL algorithms are not precise algorithms but approximated
 # algorithms (in order to save memory), so you can select as well the sample
@@ -314,7 +314,7 @@ maxclients <%= @maxclients %>
 # using the following configuration directive.
 #
 # maxmemory-samples 3
-<% if @maxmemory_samples -%>maxmemory-samples <%= @maxmemory_samples %><% end -%>
+<% if defined? @maxmemory_samples -%>maxmemory-samples <%= @maxmemory_samples %><% end -%>
 
 ############################## APPEND ONLY MODE ###############################
 


### PR DESCRIPTION
When parameters are explicitly set to `undef`, the if statements in the `redis.conf.erb` template file evaluates them as true, which means that those parameters are inserted as a literal `undef`. For example:

    syslog-facility undef

I have updated the if statements that test variables that are set to undef by default to use `defined?`, which properly returns 'false' when the parameter being tested is set to `undef`. For example:

    <% if defined? @syslog_facility %>syslog-facility <%= @syslog_facility %><%     else %># syslog-facility local0<% end %>

I found this issue running puppet agent on a Debian Jessie vagrant box. I have not tested my fork on any other operating systems or versions. I have also updated the relevant if statements in `redis-sentinel.conf.erb` but I have not installed sentinel myself.