### PR TITLE
Let Puppet manage slave priority

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,6 +18,7 @@ class redis::config {
   $workdir                      = $::redis::workdir
   $slaveof                      = $::redis::slaveof
   $masterauth                   = $::redis::masterauth
+  $slave_priority               = $::redis::params::slave_priority,
   $slave_serve_stale_data       = $::redis::slave_serve_stale_data
   $slave_read_only              = $::redis::slave_read_only
   $repl_timeout                 = $::redis::repl_timeout

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -18,7 +18,7 @@ class redis::config {
   $workdir                      = $::redis::workdir
   $slaveof                      = $::redis::slaveof
   $masterauth                   = $::redis::masterauth
-  $slave_priority               = $::redis::params::slave_priority,
+  $slave_priority               = $::redis::params::slave_priority
   $slave_serve_stale_data       = $::redis::slave_serve_stale_data
   $slave_read_only              = $::redis::slave_read_only
   $repl_timeout                 = $::redis::repl_timeout

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -474,15 +474,13 @@ class redis (
     Anchor['redis::end']
   }
 
-  # Sanity check
+  # Sanity checks
   if $::redis::slaveof {
     if $::redis::bind =~ /^127.0.0./ {
       fail "Replication is not possible when binding to ${::redis::bind}."
     }
   }
   
-  if !validate_integer($::redis::slave_priority,100,0) {
-    fail "Slave priority must be an integer between 0 and 100."
-  }
+  validate_integer($::redis::slave_priority,100,0)
 }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -290,6 +290,14 @@
 #
 #   Default: 512
 #
+# [*slave_priority*]
+#   When Sentinels are determining the next master, they consult this setting
+#   on each slave to determine eligibility and preference. A lower number makes
+#   a given slave more likely to be selected as the next master. A value of 0
+#   marks a slave as ineligible for promotion to master.
+# 
+#   Default: 100
+#
 # [*slave_read_only*]
 #   You can configure a slave instance to accept writes or not.
 #
@@ -428,6 +436,7 @@ class redis (
   $service_name                = $::redis::params::service_name,
   $service_user                = $::redis::params::service_user,
   $set_max_intset_entries      = $::redis::params::set_max_intset_entries,
+  $slave_priority              = $::redis::params::slave_priority,
   $slave_read_only             = $::redis::params::slave_read_only,
   $slave_serve_stale_data      = $::redis::params::slave_serve_stale_data,
   $slaveof                     = $::redis::params::slaveof,
@@ -470,6 +479,10 @@ class redis (
     if $::redis::bind =~ /^127.0.0./ {
       fail "Replication is not possible when binding to ${::redis::bind}."
     }
+  }
+  
+  if !validate_integer($::redis::slave_priority,100,0) {
+    fail "Slave priority must be an integer between 0 and 100."
   }
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -70,6 +70,7 @@ class redis::params {
   $slave_read_only        = true
   $slave_serve_stale_data = true
   $slaveof                = undef
+  $slave_priority         = 100
 
   case $::osfamily {
     'Debian': {

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -213,7 +213,7 @@ repl-timeout <%= @repl_timeout %>
 # Redis Sentinel for promotion.
 #
 # By default the priority is 100.
-slave-priority 100
+slave-priority <%= @slave_priority %>
 
 ################################## SECURITY ###################################
 


### PR DESCRIPTION
When a Sentinel cluster is trying to find a new master, one of the factors it takes into consideration is the 'slave-priority' value in the slave's redis.conf. A lower relative value makes a given slave more likely to be promoted to master, and a value of 0 means that slave is not considered for promotion at all.

This change defines a new parameter, slave_priority, with a default of 100, so that Puppet can manage slave priorities as necessary.