### PR TITLE
use versioncmp() to check RedHat/CentOS/SCL version

### DIFF
--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -7,7 +7,7 @@ class redis::preinstall {
   if $::redis::manage_repo {
     case $::operatingsystem {
       'RedHat', 'CentOS', 'Scientific', 'OEL': {
-        if $::operatingsystemrelease < 7 {
+        if (versioncmp($::operatingsystemrelease, '7.0') == -1) {
           $rpm_url = $::operatingsystemrelease ? {
             /^5/    => "http://download.powerstack.org/5/${::architecture}/",
             /^6/    => "http://download.powerstack.org/6/${::architecture}/",
@@ -29,7 +29,7 @@ class redis::preinstall {
           }
         }
 
-        if $::operatingsystemrelease == 7 {
+        if (versioncmp($::operatingsystemrelease, '7.0') >= 0) {
           require ::epel
         }
       }


### PR DESCRIPTION
comparing CentOS version strings wich look like '7.1.1503' gives an error

"Could not retrieve catalog from remote server: Error 400 on SERVER:
comparison of String with 7 failed at modules/redis/manifests/preinstall.pp:10"