### PR TITLE
Sentinel daemonize

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,6 +85,7 @@ class redis::params {
       $package_name              = 'redis-server'
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $sentinel_daemonize        = true
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-server'
       $sentinel_package_ensure   = 'present'
@@ -112,6 +113,7 @@ class redis::params {
       $package_name              = 'redis'
       $sentinel_config_file      = '/etc/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
+      $sentinel_daemonize        = false
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
@@ -139,6 +141,7 @@ class redis::params {
       $package_name              = 'redis'
       $sentinel_config_file      = '/usr/local/etc/redis-sentinel.conf'
       $sentinel_config_file_orig = '/usr/local/etc/redis-sentinel.conf.puppet'
+      $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
@@ -166,6 +169,7 @@ class redis::params {
       $package_name              = 'redis'
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
+      $sentinel_daemonize        = true
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -36,6 +36,11 @@
 #
 #   Default: redis/redis-sentinel.conf.erb
 #
+# [*daemonize*]
+#   Have Redis sentinel run as a daemon.
+#
+#   Default: true
+#
 # [*down_after*]
 #   Number of milliseconds the master (or any attached slave or sentinel)
 #   should be unreachable (as in, not acceptable reply to PING, continuously,
@@ -149,6 +154,7 @@ class redis::sentinel (
   $config_file_orig    = $::redis::params::sentinel_config_file_orig,
   $config_file_mode    = $::redis::params::sentinel_config_file_mode,
   $conf_template       = $::redis::params::sentinel_conf_template,
+  $daemonize           = $::redis::params::sentinel_daemonize,
   $down_after          = $::redis::params::sentinel_down_after,
   $failover_timeout    = $::redis::params::sentinel_failover_timeout,
   $init_script         = $::redis::params::sentinel_init_script,
@@ -169,7 +175,6 @@ class redis::sentinel (
   $working_dir         = $::redis::params::sentinel_working_dir,
   $notification_script = $::redis::params::sentinel_notification_script,
 ) inherits redis::params {
-  $daemonize = $::redis::daemonize
 
   unless defined(Package['$package_name']) {
     ensure_resource('package', $package_name, {


### PR DESCRIPTION
Add "daemonize" option to redis sentinel
Allow to use sentinel class without redis class on a node