### PR TITLE
Add a option to override the service provider

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -279,6 +279,11 @@
 #
 #   Default: OS dependant
 #
+# [*service_provider*]
+#   Specify the service provider to use
+#
+#   Default: undef
+#
 # [*service_user*]
 #   Specify which user to run as.
 #
@@ -426,6 +431,7 @@ class redis (
   $service_hasstatus           = $::redis::params::service_hasstatus,
   $service_manage              = $::redis::params::service_manage,
   $service_name                = $::redis::params::service_name,
+  $service_provider            = $::redis::params::service_provider,
   $service_user                = $::redis::params::service_user,
   $set_max_intset_entries      = $::redis::params::set_max_intset_entries,
   $slave_read_only             = $::redis::params::slave_read_only,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -52,6 +52,7 @@ class redis::params {
   $sentinel_init_template       = 'redis/redis-sentinel.init.erb'
   $sentinel_pid_file            = '/var/run/redis/redis-sentinel.pid'
   $sentinel_notification_script = undef
+  $service_provider             = undef
   $set_max_intset_entries       = 512
   $slowlog_log_slower_than      = 10000
   $slowlog_max_len              = 1024

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -9,6 +9,7 @@ class redis::service {
       enable     => $::redis::service_enable,
       hasrestart => $::redis::service_hasrestart,
       hasstatus  => $::redis::service_hasstatus,
+      provider   => $::redis::service_provider,
     }
   }
 }


### PR DESCRIPTION
When using this module on Debian 8, redis-server try to use the init script instead of the systemd unit file.
This change permit to overwrite service provider