### PR TITLE
Fixing typo on variable substitution on sentinel.pp

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -171,7 +171,7 @@ class redis::sentinel (
 ) inherits redis::params {
   $daemonize = $::redis::daemonize
 
-  unless defined(Package['$package_name']) {
+  unless defined(Package["$package_name"]) {
     ensure_resource('package', $package_name, {
       'ensure' => $package_ensure
     })


### PR DESCRIPTION
This gives an error when installing sentinel if you have already installed the redis-server package:
```
Duplicate declaration.....
```
**resolves #69 