### PR TITLE
Fix puppet-redis for Redis < 3

### DIFF
--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -785,8 +785,8 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
-        'content' => /cluster-enabled.*no/
+    it { should_not contain_file('/etc/redis/redis.conf').with(
+        'content' => /cluster-enabled.*/
       )
     }
   end

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -556,8 +556,6 @@ hz <%= @hz %>
 cluster-enabled yes
 cluster-config-file <%= @cluster_config_file %>
 cluster-node-timeout <%= @cluster_node_timeout %>
-<% else -%>
-cluster-enabled no
 <% end -%>
 
 


### PR DESCRIPTION
A recent commit [1] broke the support of Redis < 3 when using this
Puppet module.

The parameter 'cluster-enabled' was set to False by default, but since
Redis Clustering has been brought in Redis >= 3, Redis < 3 fails to
start [2]:
"FATAL CONFIG FILE ERROR"

It was an backwards-incompatible change in puppet-redis and we can fix
it by just not setting the paramter if 'cluster_enabled' is set to False
(default).

This patch drops the 'else' statement in the redis.conf template so by
default the cluster-enabled setting won't appear in the configuration
file. It will fix Redis < 3 support and when running Redis >=3, it will
just not activate clustering.

This change is compatible with both versions.

[1] https://github.com/arioch/puppet-redis/commit/4fb33b960a09bfb459eff20ee112bfc9e0a1c096
[2] http://stackoverflow.com/questions/27835659/redis-cluster-support-in-redis-2-8-19