### PR TITLE
Swap content for source in apt::key on Debian

### DIFF
--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -57,8 +57,8 @@ class redis::preinstall {
       'Debian': {
         include apt
         apt::key { 'dotdeb':
-          id      => '89DF5277',
-          content => 'http://www.dotdeb.org/dotdeb.gpg',
+          id     => '89DF5277',
+          source => 'http://www.dotdeb.org/dotdeb.gpg',
         }
 
         apt::source { 'dotdeb':


### PR DESCRIPTION
We ran into the following error while trying swap to this module, using manage_repo. It looks like source should be used to install the key instead, since the URL to the key is passed. 
```
Error: Execution of '/usr/bin/apt-key add /tmp/apt_key20160112-19502-12byxn4' returned 2: gpg: no valid OpenPGP data found.
Error: /Stage[main]/Redis::Preinstall/Apt::Key[dotdeb]/Apt_key[dotdeb]/ensure: change from absent to present failed: Execution of '/usr/bin/apt-key add /tmp/apt_key20160112-19502-12byxn4' returned 2: gpg: no valid OpenPGP data found.
```