### PR TITLE
change redis.conf directory for RedHat systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -111,7 +111,7 @@ class redis::params {
     'RedHat': {
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
-      $config_file               = '/etc/redis.conf'
+      $config_file               = '/etc/redis/redis.conf'
       $config_file_mode          = '0644'
       $config_group              = 'root'
       $config_owner              = 'redis'


### PR DESCRIPTION
Hi,
I would like to see the redis.conf in a sub directory of /etc, not in /etc itself.

I think there is no reason to keep the file up there.

Kind regards,

tobias