### PR TITLE
creating a seperate copy of redis.conf to allow sentinel to make changes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,5 +26,5 @@ gem 'rspec-puppet', '>=0.1.6'
 gem 'puppetlabs_spec_helper', '>=0.4.1'
 
 gem 'beaker-rspec'
-gem 'bundler', '<= 1.10.5'
+gem 'bundler', '<= 1.11.2'
 gem 'vagrant-wrapper'

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -70,7 +70,7 @@ class redis::config {
       ensure => directory,
       mode   => $::redis::config_dir_mode;
 
-    $::redis::config_file:
+    $::redis::config_file_orig:
       ensure  => present,
       content => template($::redis::conf_template);
 
@@ -79,6 +79,14 @@ class redis::config {
       group  => $::redis::service_group,
       mode   => $::redis::log_dir_mode,
       owner  => $::redis::service_user;
+  }
+
+  exec {
+    "cp -p ${::redis::config_file_orig} ${::redis::config_file}":
+      path        => '/usr/bin:/bin',
+      subscribe   => File[$::redis::config_file_orig],
+      notify      => Service[$::redis::service_name],
+      refreshonly => true;
   }
 
   # Adjust /etc/default/redis-server on Debian systems

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,16 @@
 #
 #   Default: 0755
 #
+# [*config_file_orig*]
+#   The location and name of a config file that provides the source
+#   of the redis config file. Two different files are needed
+#   because sentinel writes to the redis config file and we do
+#   not want override that when puppet is run unless there are
+#   changes from the manifests.
+#
+#   Default for deb: /etc/redis/redis.conf.puppet
+#   Default for rpm: /etc/redis.conf.puppet
+#
 # [*config_file*]
 #   Adjust main configuration file.
 #
@@ -430,6 +440,7 @@ class redis (
   $config_dir_mode             = $::redis::params::config_dir_mode,
   $config_file                 = $::redis::params::config_file,
   $config_file_mode            = $::redis::params::config_file_mode,
+  $config_file_orig            = $::redis::params::config_file_orig,
   $config_group                = $::redis::params::config_group,
   $config_owner                = $::redis::params::config_owner,
   $daemonize                   = $::redis::params::daemonize,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -85,6 +85,7 @@ class redis::params {
       $config_dir_mode           = '0755'
       $config_file               = '/etc/redis/redis.conf'
       $config_file_mode          = '0644'
+      $config_file_orig          = '/etc/redis/redis.conf.puppet'
       $config_group              = 'root'
       $config_owner              = 'redis'
       $daemonize                 = true
@@ -113,6 +114,7 @@ class redis::params {
       $config_dir_mode           = '0755'
       $config_file               = '/etc/redis.conf'
       $config_file_mode          = '0644'
+      $config_file_orig          = '/etc/redis.conf.puppet'
       $config_group              = 'root'
       $config_owner              = 'redis'
       $daemonize                 = true

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -12,7 +12,7 @@ describe 'redis', :type => :class do
 
     it { should contain_package('redis-server').with_ensure('present') }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'ensure' => 'present'
       )
     }
@@ -33,7 +33,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /activerehashing.*yes/
       )
     }
@@ -46,7 +46,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /appendfsync.*_VALUE_/
       )
     }
@@ -59,7 +59,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /appendonly.*yes/
       )
     }
@@ -72,7 +72,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /auto-aof-rewrite-min-size.*_VALUE_/
       )
     }
@@ -85,7 +85,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /auto-aof-rewrite-percentage.*_VALUE_/
       )
     }
@@ -98,7 +98,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /bind.*_VALUE_/
       )
     }
@@ -131,7 +131,7 @@ describe 'redis', :type => :class do
   describe 'with parameter: config_file_mode' do
     let (:params) { { :config_file_mode => '_VALUE_' } }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with_mode('_VALUE_') }
+    it { should contain_file('/etc/redis/redis.conf.puppet').with_mode('_VALUE_') }
   end
 
   describe 'with parameter: config_group' do
@@ -153,7 +153,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /daemonize.*yes/
       )
     }
@@ -166,7 +166,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /databases.*_VALUE_/
       )
     }
@@ -179,7 +179,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /dbfilename.*_VALUE_/
       )
     }
@@ -192,7 +192,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /hash-max-ziplist-entries.*_VALUE_/
       )
     }
@@ -205,7 +205,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /hash-max-ziplist-value.*_VALUE_/
       )
     }
@@ -218,7 +218,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /list-max-ziplist-entries.*_VALUE_/
       )
     }
@@ -231,7 +231,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /list-max-ziplist-value.*_VALUE_/
       )
     }
@@ -257,7 +257,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /logfile.*_VALUE_/
       )
     }
@@ -270,7 +270,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /loglevel.*_VALUE_/
       )
     }
@@ -338,7 +338,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /masterauth.*_VALUE_/
       )
     }
@@ -351,7 +351,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /maxclients.*_VALUE_/
       )
     }
@@ -364,7 +364,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /maxmemory.*_VALUE_/
       )
     }
@@ -377,7 +377,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /maxmemory-policy.*_VALUE_/
       )
     }
@@ -390,7 +390,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /maxmemory-samples.*_VALUE_/
       )
     }
@@ -403,7 +403,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').that_notifies('Service[redis-server]'
+    it { should contain_file('/etc/redis/redis.conf.puppet').that_notifies('Service[redis-server]'
       )
     }
   end
@@ -415,7 +415,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /no-appendfsync-on-rewrite.*yes/
       )
     }
@@ -443,7 +443,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /pidfile.*_VALUE_/
       )
     }
@@ -456,7 +456,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /port.*_VALUE_/
       )
     }
@@ -469,7 +469,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /hz.*_VALUE_/
       )
     }
@@ -482,7 +482,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /rdbcompression.*yes/
       )
     }
@@ -495,7 +495,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /repl-ping-slave-period.*1/
       )
     }
@@ -508,7 +508,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /repl-timeout.*1/
       )
     }
@@ -521,7 +521,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /requirepass.*_VALUE_/
       )
     }

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -122,8 +122,8 @@ describe 'redis', :type => :class do
     it { should contain_file('/var/log/redis').with_mode('_VALUE_') }
   end
 
-  describe 'with parameter: config_file' do
-    let (:params) { { :config_file => '_VALUE_' } }
+  describe 'with parameter: config_file_orig' do
+    let (:params) { { :config_file_orig => '_VALUE_' } }
 
     it { should contain_file('_VALUE_') }
   end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -12,7 +12,7 @@ describe 'redis', :type => :class do
 
     it { should contain_package('redis-server').with_ensure('present') }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'ensure' => 'present'
       )
     }
@@ -33,7 +33,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /activerehashing.*yes/
       )
     }
@@ -46,7 +46,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /appendfsync.*_VALUE_/
       )
     }
@@ -59,7 +59,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /appendonly.*yes/
       )
     }
@@ -72,7 +72,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /auto-aof-rewrite-min-size.*_VALUE_/
       )
     }
@@ -85,7 +85,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /auto-aof-rewrite-percentage.*_VALUE_/
       )
     }
@@ -98,7 +98,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /bind.*_VALUE_/
       )
     }
@@ -131,7 +131,7 @@ describe 'redis', :type => :class do
   describe 'with parameter: config_file_mode' do
     let (:params) { { :config_file_mode => '_VALUE_' } }
 
-    it { should contain_file('/etc/redis/redis.conf').with_mode('_VALUE_') }
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with_mode('_VALUE_') }
   end
 
   describe 'with parameter: config_group' do
@@ -153,7 +153,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /daemonize.*yes/
       )
     }
@@ -166,7 +166,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /databases.*_VALUE_/
       )
     }
@@ -179,7 +179,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /dbfilename.*_VALUE_/
       )
     }
@@ -192,7 +192,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /hash-max-ziplist-entries.*_VALUE_/
       )
     }
@@ -205,7 +205,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /hash-max-ziplist-value.*_VALUE_/
       )
     }
@@ -218,7 +218,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /list-max-ziplist-entries.*_VALUE_/
       )
     }
@@ -231,7 +231,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /list-max-ziplist-value.*_VALUE_/
       )
     }
@@ -257,7 +257,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /logfile.*_VALUE_/
       )
     }
@@ -270,7 +270,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /loglevel.*_VALUE_/
       )
     }
@@ -338,7 +338,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /masterauth.*_VALUE_/
       )
     }
@@ -351,7 +351,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /maxclients.*_VALUE_/
       )
     }
@@ -364,7 +364,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /maxmemory.*_VALUE_/
       )
     }
@@ -377,7 +377,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /maxmemory-policy.*_VALUE_/
       )
     }
@@ -390,7 +390,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /maxmemory-samples.*_VALUE_/
       )
     }
@@ -403,7 +403,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').that_notifies('Service[redis-server]'
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').that_notifies('Service[redis-server]'
       )
     }
   end
@@ -415,7 +415,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /no-appendfsync-on-rewrite.*yes/
       )
     }
@@ -443,7 +443,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /pidfile.*_VALUE_/
       )
     }
@@ -456,7 +456,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /port.*_VALUE_/
       )
     }
@@ -469,7 +469,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /hz.*_VALUE_/
       )
     }
@@ -482,7 +482,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /rdbcompression.*yes/
       )
     }
@@ -495,7 +495,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /repl-ping-slave-period.*1/
       )
     }
@@ -508,7 +508,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /repl-timeout.*1/
       )
     }
@@ -521,7 +521,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet.puppet').with(
         'content' => /requirepass.*_VALUE_/
       )
     }
@@ -535,7 +535,7 @@ describe 'redis', :type => :class do
         }
       }
 
-      it { should contain_file('/etc/redis/redis.conf').with(
+      it { should contain_file('/etc/redis/redis.conf.puppet').with(
           'content' => /^save/
         )
       }
@@ -548,7 +548,7 @@ describe 'redis', :type => :class do
         }
       }
 
-      it { should contain_file('/etc/redis/redis.conf').with(
+      it { should contain_file('/etc/redis/redis.conf.puppet').with(
           'content' => /^(?!save)/
         )
       }
@@ -610,7 +610,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /set-max-intset-entries.*_VALUE_/
       )
     }
@@ -623,7 +623,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /slave-read-only.*yes/
       )
     }
@@ -636,7 +636,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /slave-serve-stale-data.*yes/
       )
     }
@@ -666,7 +666,7 @@ describe 'redis', :type => :class do
         }
       }
 
-      it { should contain_file('/etc/redis/redis.conf').with(
+      it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /^slaveof _VALUE_/
       )
     }
@@ -680,7 +680,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /slowlog-log-slower-than.*_VALUE_/
       )
     }
@@ -693,7 +693,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /slowlog-max-len.*_VALUE_/
       )
     }
@@ -706,7 +706,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /stop-writes-on-bgsave-error.*yes/
       )
     }
@@ -719,7 +719,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /syslog-enabled yes/
       )
     }
@@ -733,7 +733,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /syslog-facility.*_VALUE_/
       )
     }
@@ -746,7 +746,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /tcp-keepalive.*_VALUE_/
       )
     }
@@ -759,7 +759,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /timeout.*_VALUE_/
       )
     }
@@ -772,7 +772,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /dir.*_VALUE_/
       )
     }
@@ -785,7 +785,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /zset-max-ziplist-entries.*_VALUE_/
       )
     }
@@ -798,7 +798,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /zset-max-ziplist-value.*_VALUE_/
       )
     }
@@ -811,7 +811,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should_not contain_file('/etc/redis/redis.conf').with(
+    it { should_not contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /cluster-enabled/
       )
     }
@@ -824,7 +824,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /cluster-enabled.*yes/
       )
     }
@@ -838,7 +838,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /cluster-config-file.*_VALUE_/
       )
     }
@@ -852,7 +852,7 @@ describe 'redis', :type => :class do
       }
     }
 
-    it { should contain_file('/etc/redis/redis.conf').with(
+    it { should contain_file('/etc/redis/redis.conf.puppet').with(
         'content' => /cluster-node-timeout.*_VALUE_/
       )
     }


### PR DESCRIPTION
When sentinel detects a failover it reconfigures redis.conf to change the 'slaveof' setting.  Puppet was then changing it back to the initial setting.  This uses the same configuration as sentinel.pp had in place.