### PR TITLE
Make notification of service optional

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -85,9 +85,8 @@ class redis::config {
     "cp -p ${::redis::config_file_orig} ${::redis::config_file}":
       path        => '/usr/bin:/bin',
       subscribe   => File[$::redis::config_file_orig],
-      notify      => Service[$::redis::service_name],
       refreshonly => true;
-  }
+  } ~> Service <| title == $::redis::service_name |>
 
   # Adjust /etc/default/redis-server on Debian systems
   case $::osfamily {


### PR DESCRIPTION
Prevent catalog failures in cases where service_manage is
not enabled