### PR TITLE
Update preinstall

### DIFF
--- a/manifests/preinstall.pp
+++ b/manifests/preinstall.pp
@@ -56,17 +56,14 @@ class redis::preinstall {
 
       'Debian': {
         include apt
-        apt::key { 'dotdeb':
-          id     => '89DF5277',
-          source => 'http://www.dotdeb.org/dotdeb.gpg',
-        }
-
         apt::source { 'dotdeb':
-          location => 'http://packages.dotdeb.org',
-          release  => $::lsbdistcodename,
-          repos    => 'all',
-          require  => Apt::Key['dotdeb'],
-        }
+          location    => 'http://packages.dotdeb.org/',
+          release     =>  $::lsbdistcodename,
+          repos       => 'all',
+          key         => { id => '89DF5277', source => 'http://www.dotdeb.org/dotdeb.gpg', }, 
+          include_src => true
+        } 
+        
       }
 
       'Ubuntu': {


### PR DESCRIPTION
I was testing your module, a problem with apt::source 'dotdeb' came up:

```
Error: Execution of '/usr/bin/apt-key add /tmp/apt_key20160622-3917-85x946' returned 2: gpg: no valid OpenPGP data found.
Error: /Stage[main]/Redis::Preinstall/Apt::Key[dotdeb]/Apt_key[dotdeb]/ensure: change from absent to present failed: Execution of '/usr/bin/apt-key add /tmp/apt_key20160622-3917-85x946' returned 2: gpg: no valid OpenPGP data found.
Notice: /Stage[main]/Redis::Preinstall/Apt::Key[dotdeb]/Anchor[apt_key 89DF5277 present]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Preinstall/Apt::Key[dotdeb]/Anchor[apt_key 89DF5277 present]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis::Preinstall/Apt::Source[dotdeb]/Apt::Setting[list-dotdeb]/File[/etc/apt/sources.list.d/dotdeb.list]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Preinstall/Apt::Source[dotdeb]/Apt::Setting[list-dotdeb]/File[/etc/apt/sources.list.d/dotdeb.list]: Skipping because of failed dependencies
Notice: /Package[redis-server]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Package[redis-server]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis::Config/File[/var/log/redis]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Config/File[/var/log/redis]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis::Config/File[/etc/default/redis-server]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Config/File[/etc/default/redis-server]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis::Config/File[/etc/redis]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Config/File[/etc/redis]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis::Config/Augeas[redis ulimit]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Config/Augeas[redis ulimit]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis::Config/File[/etc/redis/redis.conf]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Config/File[/etc/redis/redis.conf]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis::Service/Service[redis-server]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis::Service/Service[redis-server]: Skipping because of failed dependencies
Notice: /Stage[main]/Redis/Anchor[redis::end]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Redis/Anchor[redis::end]: Skipping because of failed dependencies
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Dependency Apt_key[dotdeb] has failures: true
Warning: /Stage[main]/Apt::Update/Exec[apt_update]: Skipping because of failed dependencies
```
I'm used to use this way.

