### PR TITLE
Remove single quotes around variable

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,7 +3,7 @@
 # This class installs the application.
 #
 class redis::install {
-  unless defined(Package['$::redis::package_name']) {
+  unless defined(Package[$::redis::package_name]) {
     ensure_resource('package', $::redis::package_name, {
       'ensure' => $::redis::package_ensure
     })


### PR DESCRIPTION
Single quotes around variable, meant that it was checking for a package literally called '$::redis::package_name', rather than the actual package_name, passed to the redis class.