### PR TITLE
Sentinel Bind

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class redis::params {
   $requirepass                     = undef
   $save_db_to_disk                 = true
   $sentinel_auth_pass              = undef
+  $sentinel_bind                   = undef
   $sentinel_config_file_mode       = '0644'
   $sentinel_config_group           = 'root'
   $sentinel_config_owner           = 'redis'

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -106,6 +106,12 @@
 #
 #   Default: 2
 #
+# [*sentinel_bind*]
+#   Allow optional sentinel server ip binding.  Can help overcome
+#   issues arising from protect-mode added Redis 3.2
+#
+#   Default: undef
+#
 # [*sentinel_port*]
 #   The port of sentinel server.
 #
@@ -173,6 +179,7 @@ class redis::sentinel (
   $parallel_sync          = $::redis::params::sentinel_parallel_sync,
   $pid_file               = $::redis::params::sentinel_pid_file,
   $quorum                 = $::redis::params::sentinel_quorum,
+  $sentinel_bind          = $::redis::params::sentinel_bind,
   $sentinel_port          = $::redis::params::sentinel_port,
   $service_group          = $::redis::params::service_group,
   $service_name           = $::redis::params::sentinel_service_name,

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -1,3 +1,6 @@
+<% if @sentinel_bind -%>
+bind <%= @sentinel_bind %>
+<% end -%>
 port <%= @sentinel_port %>
 dir <%= @working_dir %>
 <% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end %>


### PR DESCRIPTION
Redis 3.2 introduced '[protected-mode](http://redis.io/topics/security#protected-mode)' to enhance security.   The feature introduces an error in the sentinels when trying to connect from non loopback interface : 

> DENIED Redis is running in protected mode because protected mode is enabled, no bind address was specified, no authentication password is requested to clients....

Fix adds 'bind' to the sentinel template in order to allow the sentinels to communicate.

```
class { 'redis::sentinel':
  sentinel_bind => '0.0.0.0',
}
```

Example tested in production, Centos 6.5, Redis 3.2.1.  Configuration, Master / Slave plus multiple Client Sentinels.

