### PR TITLE
Changed default service_hasstatus variable from false to true for Debian params.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -119,7 +119,7 @@ class redis::params {
       $service_ensure            = 'running'
       $service_group             = 'redis'
       $service_hasrestart        = true
-      $service_hasstatus         = false
+      $service_hasstatus         = true
       $service_name              = 'redis-server'
       $service_user              = 'redis'
       $ppa_repo                  = 'ppa:chris-lea/redis-server'

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -82,5 +82,10 @@ describe 'redis::sentinel', :type => :class do
       )
     }
   end
+  describe 'with parameter: service_hasstatus' do
+    let (:params) { { :service_hasstatus => true } }
+
+    it { should contain_service('redis-sentinel').with_hasstatus(true) }
+  end
 
 end


### PR DESCRIPTION
Both sentinel and redis have working status argument to init script. Original setting for service_hasstatus to false casued displaying messages:

`Notice: /Stage[main]/Redis::Sentinel/Service[redis-sentinel]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Redis::Sentinel/Service[redis-sentinel]: Unscheduling refresh on Service[redis-sentinel]`

after every puppet run.