### PR TITLE
Add control over workdir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -90,6 +90,12 @@ class redis::config {
       ensure  => present,
       content => template($::redis::conf_template);
 
+    $::redis::workdir:
+      ensure => directory,
+      owner  => $::redis::service_user,
+      group  => $::redis::service_group,
+      mode   => $::redis::workdir_mode;
+
     $::redis::log_dir:
       ensure => directory,
       group  => $::redis::service_group,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -466,6 +466,11 @@
 #
 #   Default: /var/lib/redis/
 #
+# [*workdir_mode*]
+#   Adjust mode for directory containing DB.
+#
+#   Default: 0755
+#
 # [*zset_max_ziplist_entries*]
 #   Set max entries for sorted sets.
 #
@@ -482,7 +487,8 @@
 #   Default: false
 #
 # [*cluster_config_file*]
-#   Config file for saving cluster nodes configuration. This file is never touched by humans.
+#   Config file for saving cluster nodes configuration. This file is never
+#   touched by humans.
 #   Only set if cluster_enabled is true
 #
 #   Default: nodes.conf
@@ -587,6 +593,7 @@ class redis (
   $unixsocketperm                = $::redis::params::unixsocketperm,
   $ulimit                        = $::redis::params::ulimit,
   $workdir                       = $::redis::params::workdir,
+  $workdir_mode                  = $::redis::params::workdir_mode,
   $zset_max_ziplist_entries      = $::redis::params::zset_max_ziplist_entries,
   $zset_max_ziplist_value        = $::redis::params::zset_max_ziplist_value,
   $cluster_enabled               = $::redis::params::cluster_enabled,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -123,6 +123,7 @@ class redis::params {
       $service_name              = 'redis-server'
       $service_user              = 'redis'
       $ppa_repo                  = 'ppa:chris-lea/redis-server'
+      $workdir_mode              = '0755'
     }
 
     'RedHat': {
@@ -152,6 +153,7 @@ class redis::params {
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
+      $workdir_mode              = '0755'
     }
 
     'FreeBSD': {
@@ -180,6 +182,7 @@ class redis::params {
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
+      $workdir_mode              = '0755'
     }
 
     'Suse': {
@@ -208,6 +211,7 @@ class redis::params {
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
+      $workdir_mode              = '0755'
     }
 
     default: {


### PR DESCRIPTION
It's pretty not elegant to create and control custom workdir outside the redis puppet module. Because of that I'm sending small patch making it possible and straightforward.
