### PR TITLE
Allow binding port for Sentinel

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,6 +43,7 @@ class redis::params {
   $requirepass                     = undef
   $save_db_to_disk                 = true
   $sentinel_auth_pass              = undef
+  $sentinel_bind                   = '127.0.0.1'
   $sentinel_config_file_mode       = '0644'
   $sentinel_config_group           = 'root'
   $sentinel_config_owner           = 'redis'
@@ -215,4 +216,3 @@ class redis::params {
     }
   }
 }
-

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -106,6 +106,11 @@
 #
 #   Default: 2
 #
+# [*sentinel_bind*]
+#   The IP to bind sentinel server.
+#
+#   Default: 127.0.0.1
+#
 # [*sentinel_port*]
 #   The port of sentinel server.
 #
@@ -173,6 +178,7 @@ class redis::sentinel (
   $parallel_sync          = $::redis::params::sentinel_parallel_sync,
   $pid_file               = $::redis::params::sentinel_pid_file,
   $quorum                 = $::redis::params::sentinel_quorum,
+  $sentinel_bind          = $::redis::params::sentinel_bind,
   $sentinel_port          = $::redis::params::sentinel_port,
   $service_group          = $::redis::params::service_group,
   $service_name           = $::redis::params::sentinel_service_name,

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 $expected_noparams_content = <<EOF
+bind 127.0.0.1
 port 26379
 dir /tmp
 daemonize yes
@@ -15,6 +16,7 @@ logfile /var/log/redis/redis.log
 EOF
 
 $expected_params_content = <<EOF
+bind 1.2.3.4
 port 26379
 dir /tmp
 daemonize yes
@@ -66,6 +68,7 @@ describe 'redis::sentinel', :type => :class do
     let (:params) {
       {
         :auth_pass              => 'password',
+        :sentinel_bind          => '1.2.3.4',
         :master_name            => 'cow',
         :down_after             => 6000,
         :log_file               => '/tmp/barn-sentinel.log',

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -1,3 +1,4 @@
+bind <%= @sentinel_bind %>
 port <%= @sentinel_port %>
 dir <%= @working_dir %>
 <% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end %>


### PR DESCRIPTION
The protected mode of Redis will prevent the Sentinel from starting up
if it is not bound to a specific interface.  This allows configuring
sentinel to be bound to an interface.