### PR TITLE
Changes package installation

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,6 +175,11 @@
 #
 #   Default: false
 #
+# [*manage_package*]
+#   Enable/disable management of package
+#
+#   Default: true
+#
 # [*masterauth*]
 #   If the master is password protected (using the "requirepass" configuration
 #   directive below) it is possible to tell the slave to authenticate before
@@ -547,6 +552,7 @@ class redis (
   $log_dir_mode                  = $::redis::params::log_dir_mode,
   $log_file                      = $::redis::params::log_file,
   $log_level                     = $::redis::params::log_level,
+  $manage_package                = $::redis::params::manage_package,
   $manage_repo                   = $::redis::params::manage_repo,
   $masterauth                    = $::redis::params::masterauth,
   $maxclients                    = $::redis::params::maxclients,

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,10 +3,10 @@
 # This class installs the application.
 #
 class redis::install {
-  unless defined(Package[$::redis::package_name]) {
-    ensure_resource('package', $::redis::package_name, {
-      'ensure' => $::redis::package_ensure
-    })
+  if $::redis::manage_package {
+    package { $::redis::package_name:
+      ensure => $::redis::package_ensure,
+    }
   }
 }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@
 class redis::params {
   # Generic
   $manage_repo = false
+  $manage_package = true
 
   # redis.conf.erb
   $activerehashing                 = true


### PR DESCRIPTION
- Right now package is checked with a defined function
- If user doesn’t want to manage the package or is managing somewhere else, they should use the parameter not to manage it
