### PR TITLE
Largish commit. In essence it implements a couple of features. multip…

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -525,6 +525,8 @@ class redis (
   $auto_aof_rewrite_percentage   = $::redis::params::auto_aof_rewrite_percentage,
   $bind                          = $::redis::params::bind,
   $conf_template                 = $::redis::params::conf_template,
+  $redis_init_template           = $::redis::params::redis_init_template,
+  $redis_init_file_mode          = $::redis::params::redis_init_file_mode,
   $config_dir                    = $::redis::params::config_dir,
   $config_dir_mode               = $::redis::params::config_dir_mode,
   $config_file                   = $::redis::params::config_file,
@@ -586,6 +588,7 @@ class redis (
   $slave_read_only               = $::redis::params::slave_read_only,
   $slave_serve_stale_data        = $::redis::params::slave_serve_stale_data,
   $slaveof                       = $::redis::params::slaveof,
+  $slaveof_port                  = $::redis::params::slaveof_port,
   $slowlog_log_slower_than       = $::redis::params::slowlog_log_slower_than,
   $slowlog_max_len               = $::redis::params::slowlog_max_len,
   $stop_writes_on_bgsave_error   = $::redis::params::stop_writes_on_bgsave_error,
@@ -600,34 +603,51 @@ class redis (
   $workdir                       = $::redis::params::workdir,
   $zset_max_ziplist_entries      = $::redis::params::zset_max_ziplist_entries,
   $zset_max_ziplist_value        = $::redis::params::zset_max_ziplist_value,
+  $client_output_buffer_limit_normal = $::redis::params::client_output_buffer_limit_normal,
+  $client_output_buffer_limit_slave  = $::redis::params::client_output_buffer_limit_slave,
+  $client_output_buffer_limit_pubsub = $::redis::params::client_output_buffer_limit_pubsub,
   $cluster_enabled               = $::redis::params::cluster_enabled,
   $cluster_config_file           = $::redis::params::cluster_config_file,
   $cluster_node_timeout          = $::redis::params::cluster_node_timeout,
+  $instances                     = $::redis::params::instances,
+  $redis_binary_path             = $::redis::params::redis_binary_path,
+  $redis_binary_name             = $::redis::params::redis_binary_name,
+
+
 ) inherits redis::params {
   anchor { 'redis::begin': }
   anchor { 'redis::end': }
 
-  include ::redis::preinstall
-  include ::redis::install
-  include ::redis::config
-  include ::redis::service
-
-  if $::redis::notify_service {
-    Anchor['redis::begin'] ->
-    Class['redis::preinstall'] ->
-    Class['redis::install'] ->
-    Class['redis::config'] ~>
-    Class['redis::service'] ->
-    Anchor['redis::end']
+  if $::redis::instances {
+      include ::redis::preinstall
+      include ::redis::install
+      include ::redis::config
+      Anchor['redis::begin'] ->
+      Class['redis::preinstall'] ->
+      Class['redis::install'] ->
+      Class['redis::config'] ~>
+      Anchor['redis::end']
   } else {
-    Anchor['redis::begin'] ->
-    Class['redis::preinstall'] ->
-    Class['redis::install'] ->
-    Class['redis::config'] ->
-    Class['redis::service'] ->
-    Anchor['redis::end']
-  }
-
+      include ::redis::preinstall
+      include ::redis::install
+      include ::redis::config
+      include ::redis::service
+	  if $::redis::notify_service {
+	    Anchor['redis::begin'] ->
+	    Class['redis::preinstall'] ->
+	    Class['redis::install'] ->
+	    Class['redis::config'] ~>
+	    Class['redis::service'] ~>
+	    Anchor['redis::end']
+	  } else {
+	    Anchor['redis::begin'] ->
+	    Class['redis::preinstall'] ->
+	    Class['redis::install'] ->
+	    Class['redis::config'] ->
+	    Class['redis::service'] ->
+	    Anchor['redis::end']
+	  }
+ }
   # Sanity check
   if $::redis::slaveof {
     if $::redis::bind =~ /^127.0.0./ {

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -3,9 +3,10 @@
 # This class installs the application.
 #
 class redis::install {
-  unless defined(Package[$::redis::package_name]) {
+  unless defined(Package['$::redis::package_name']) {
     ensure_resource('package', $::redis::package_name, {
-      'ensure' => $::redis::package_ensure
+      'ensure' => $::redis::package_ensure,
+      'provider' => $::redis::provider,
     })
   }
 }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -1,0 +1,157 @@
+#
+#
+define redis::instance (
+  $activerehashing                   = $::redis::activerehashing,
+  $aof_load_truncated                = $::redis::aof_load_truncated,
+  $aof_rewrite_incremental_fsync     = $::redis::aof_rewrite_incremental_fsync,
+  $appendfilename                    = $::redis::appendfilename,
+  $appendfsync                       = $::redis::appendfsync,
+  $appendonly                        = $::redis::appendonly,
+  $auto_aof_rewrite_min_size         = $::redis::auto_aof_rewrite_min_size,
+  $auto_aof_rewrite_percentage       = $::redis::auto_aof_rewrite_percentage,
+  $bind                              = $::redis::bind,
+  $cluster_config_file               = $::redis::cluster_config_file,
+  $cluster_enabled                   = $::redis::cluster_enabled,
+  $cluster_node_timeout              = $::redis::cluster_node_timeout,
+  $daemonize                         = $::redis::daemonize,
+  $databases                         = $::redis::databases,
+  $dbfilename                        = $::redis::dbfilename,
+  $extra_config_file                 = $::redis::extra_config_file,
+  $hash_max_ziplist_entries          = $::redis::hash_max_ziplist_entries,
+  $hash_max_ziplist_value            = $::redis::hash_max_ziplist_value,
+  $hll_sparse_max_bytes              = $::redis::hll_sparse_max_bytes,
+  $hz                                = $::redis::hz,
+  $latency_monitor_threshold         = $::redis::latency_monitor_threshold,
+  $list_max_ziplist_entries          = $::redis::list_max_ziplist_entries,
+  $list_max_ziplist_value            = $::redis::list_max_ziplist_value,
+  $log_level                         = $::redis::log_level,
+  $masterauth                        = $::redis::masterauth,
+  $maxclients                        = $::redis::maxclients,
+  $maxmemory                         = $::redis::maxmemory,
+  $maxmemory_policy                  = $::redis::maxmemory_policy,
+  $maxmemory_samples                 = $::redis::maxmemory_samples,
+  $min_slaves_max_lag                = $::redis::min_slaves_max_lag,
+  $min_slaves_to_write               = $::redis::min_slaves_to_write,
+  $no_appendfsync_on_rewrite         = $::redis::no_appendfsync_on_rewrite,
+  $notify_keyspace_events            = $::redis::notify_keyspace_events,
+  $port                              = $::redis::port,
+  $rdbcompression                    = $::redis::rdbcompression,
+  $repl_backlog_size                 = $::redis::repl_backlog_size,
+  $repl_backlog_ttl                  = $::redis::repl_backlog_ttl,
+  $repl_disable_tcp_nodelay          = $::redis::repl_disable_tcp_nodelay,
+  $repl_ping_slave_period            = $::redis::repl_ping_slave_period,
+  $repl_timeout                      = $::redis::repl_timeout,
+  $requirepass                       = $::redis::requirepass,
+  $save_db_to_disk                   = $::redis::save_db_to_disk,
+  $set_max_intset_entries            = $::redis::set_max_intset_entries,
+  $slave_priority                    = $::redis::slave_priority,
+  $slave_read_only                   = $::redis::slave_read_only,
+  $slave_serve_stale_data            = $::redis::slave_serve_stale_data,
+  $global_slaveof                    = $::redis::slaveof,
+  $slowlog_log_slower_than           = $::redis::slowlog_log_slower_than,
+  $slowlog_max_len                   = $::redis::slowlog_max_len,
+  $stop_writes_on_bgsave_error       = $::redis::stop_writes_on_bgsave_error,
+  $syslog_enabled                    = $::redis::syslog_enabled,
+  $syslog_facility                   = $::redis::syslog_facility,
+  $tcp_backlog                       = $::redis::tcp_backlog,
+  $tcp_keepalive                     = $::redis::tcp_keepalive,
+  $timeout                           = $::redis::timeout,
+  $unixsocket                        = $::redis::unixsocket,
+  $unixsocketperm                    = $::redis::unixsocketperm,
+  $workdir                           = $::redis::workdir,
+  $zset_max_ziplist_entries          = $::redis::zset_max_ziplist_entries,
+  $zset_max_ziplist_value            = $::redis::zset_max_ziplist_value,
+  $client_output_buffer_limit_normal = $::redis::client_output_buffer_limit_normal,
+  $client_output_buffer_limit_slave  = $::redis::client_output_buffer_limit_slave,
+  $client_output_buffer_limit_pubsub = $::redis::client_output_buffer_limit_pubsub,
+ ) {
+
+  $instance_name          = "redis-${title}"
+  $service_name           = $instance_name
+  $config_dir             = "${::redis::config_dir}/${service_name}"
+  $config_file            = "$config_dir/redis.conf"
+  $config_file_orig       = "$config_dir/redis.conf.puppet"
+  $instance_init_file     = "/etc/init.d/${service_name}"
+  $pid_file               = "/var/run/redis/${instance_name}.pid"
+  $log_file               = "/var/log/redis/${instance_name}.log"
+  $redis_binary_path      = $::redis::redis_binary_path
+  $redis_binary_name      = "$instance_name"
+  $instance_symlink       = "${::redis::redis_binary_path}/$instance_name"
+  $redis_server_binary    = "${::redis::redis_binary_path}/${::redis::redis_binary_name}"
+
+  # We should not be making a host a slave of itself
+  if ($global_slaveof != $::fqdn) {
+      $slaveof = $global_slaveof
+      $slaveof_port = $port
+  }
+  if $::redis::notify_service {
+    service { $service_name:
+      ensure     => $::redis::service_ensure,
+      enable     => $::redis::service_enable,
+      hasrestart => $::redis::service_hasrestart,
+      hasstatus  => $::redis::service_hasstatus,
+      provider   => $::redis::service_provider,
+    }
+
+    File {
+      owner  => $::redis::config_owner,
+      group  => $::redis::config_group,
+      mode   => $::redis::config_file_mode,
+      notify => Service[$service_name]
+    }
+  } else {
+    File {
+      owner => $::redis::config_owner,
+      group => $::redis::config_group,
+      mode  => $::redis::config_file_mode,
+    }
+  }
+
+  file {
+    $config_dir:
+      ensure => directory,
+      mode   => $::redis::config_dir_mode;
+
+    $config_file_orig:
+      ensure  => present,
+      content => template($::redis::conf_template);
+
+    $instance_init_file:
+      ensure  => present,
+      content => template($::redis::redis_init_template),
+      mode    => $::redis::redis_init_file_mode;
+
+    $instance_symlink:
+      ensure  => 'link',
+      target  => $redis_server_binary;
+  }
+
+  exec {
+    "cp -p ${config_file_orig} ${config_file}":
+      path        => '/usr/bin:/bin',
+      subscribe   => File[$config_file_orig],
+      refreshonly => true;
+  } ~> Service <| title == $::redis::service_name |>
+
+  # Adjust /etc/default/redis-server on Debian systems
+  case $::osfamily {
+    'Debian': {
+      file { '/etc/default/redis-server':
+        ensure => present,
+        group  => $::redis::config_group,
+        mode   => $::redis::config_file_mode,
+        owner  => $::redis::config_owner,
+      }
+
+      if $::redis::ulimit {
+        augeas { 'redis ulimit' :
+          context => '/files/etc/default/redis-server',
+          changes => "set ULIMIT ${::redis::ulimit}",
+        }
+      }
+    }
+
+    default: {
+    }
+  }
+}

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -5,6 +5,7 @@
 class redis::params {
   # Generic
   $manage_repo = false
+  $instances   = undef
 
   # redis.conf.erb
   $activerehashing                 = true
@@ -42,6 +43,8 @@ class redis::params {
   $requirepass                     = undef
   $save_db_to_disk                 = true
   $save_db_to_disk_interval        = {'900' =>'1', '300' => '10', '60' => '10000'}
+  $redis_init_template             = 'redis/redis.init.erb'
+  $redis_init_file_mode            = '0755'
   $sentinel_auth_pass              = undef
   $sentinel_bind                   = undef
   $sentinel_config_file_mode       = '0644'
@@ -56,10 +59,13 @@ class redis::params {
   $sentinel_quorum                 = 2
   $sentinel_service_name           = 'redis-sentinel'
   $sentinel_working_dir            = '/tmp'
-  $sentinel_init_template          = 'redis/redis-sentinel.init.erb'
   $sentinel_pid_file               = '/var/run/redis/redis-sentinel.pid'
   $sentinel_notification_script    = undef
   $sentinel_client_reconfig_script = undef
+  $sentinel_discover_master        = false
+  $sentinel_multiple_instances     = false
+  $sentinel_members                = {}
+  $sentinel_log_file               = '/var/log/redis/sentinel.log'
   $service_provider                = undef
   $set_max_intset_entries          = 512
   $slave_priority                  = 100
@@ -76,6 +82,9 @@ class redis::params {
   $unixsocketperm                  = 755
   $zset_max_ziplist_entries        = 128
   $zset_max_ziplist_value          = 64
+  $client_output_buffer_limit_normal = '0 0 0'
+  $client_output_buffer_limit_slave  = '256mb 64mb 60'
+  $client_output_buffer_limit_pubsub = '32mb 8mb 60'
 
   # redis.conf.erb - replication
   $masterauth               = undef
@@ -89,6 +98,7 @@ class redis::params {
   $slave_read_only          = true
   $slave_serve_stale_data   = true
   $slaveof                  = undef
+  $slaveport                = undef
 
   # redis.conf.erb - redis 3.0 clustering
   $cluster_enabled        = false
@@ -115,6 +125,7 @@ class redis::params {
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis-server'
       $sentinel_package_ensure   = 'present'
+      $sentinel_init_template    = 'redis/redis-sentinel.init.erb'
       $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
@@ -125,12 +136,14 @@ class redis::params {
       $service_user              = 'redis'
       $ppa_repo                  = 'ppa:chris-lea/redis-server'
       $workdir                   = '/var/lib/redis/'
+      $redis_binary_path         = '/usr/bin/'
+      $redis_binary_name         = 'redis-server'
     }
 
     'RedHat': {
       $config_dir                = '/etc/redis'
       $config_dir_mode           = '0755'
-      $config_file               = '/etc/redis.conf'
+      $config_file               = '/etc/redis/redis.conf'
       $config_file_mode          = '0644'
       $config_file_orig          = '/etc/redis.conf.puppet'
       $config_group              = 'root'
@@ -140,12 +153,13 @@ class redis::params {
       $package_ensure            = 'present'
       $package_name              = 'redis'
       $pid_file                  = '/var/run/redis/redis-server.pid'
-      $sentinel_config_file      = '/etc/redis-sentinel.conf'
-      $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
+      $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
+      $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
       $sentinel_daemonize        = false
-      $sentinel_init_script      = undef
+      $sentinel_init_script      = '/etc/init.d/redis-sentinel'
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
+      $sentinel_init_template    = 'redis/redis-sentinel.init.redhat.erb'
       $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
@@ -156,6 +170,9 @@ class redis::params {
       $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/lib/redis/'
+      $provider                  = 'yum'
+      $redis_binary_path         = '/usr/bin/'
+      $redis_binary_name         = 'redis-server'
     }
 
     'FreeBSD': {
@@ -177,6 +194,7 @@ class redis::params {
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
+      $sentinel_init_template    = 'redis/redis-sentinel.init.erb'
       $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
@@ -187,6 +205,8 @@ class redis::params {
       $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/db/redis/'
+      $redis_binary_path         = '/usr/bin/'
+      $redis_binary_name         = 'redis-server'
     }
 
     'Suse': {
@@ -207,6 +227,7 @@ class redis::params {
       $sentinel_init_script      = undef
       $sentinel_package_name     = 'redis'
       $sentinel_package_ensure   = 'present'
+      $sentinel_init_template    = 'redis/redis-sentinel.init.erb'
       $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
@@ -217,6 +238,8 @@ class redis::params {
       $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/lib/redis/'
+      $redis_binary_path         = '/usr/bin/'
+      $redis_binary_name         = 'redis-server'
     }
 
     default: {
@@ -224,3 +247,4 @@ class redis::params {
     }
   }
 }
+

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -105,7 +105,6 @@
 #   signal sdown state.
 #
 #   Default: 2
-#
 # [*sentinel_bind*]
 #   Allow optional sentinel server ip binding.  Can help overcome
 #   issues arising from protect-mode added Redis 3.2
@@ -170,7 +169,7 @@ class redis::sentinel (
   $failover_timeout       = $::redis::params::sentinel_failover_timeout,
   $init_script            = $::redis::params::sentinel_init_script,
   $init_template          = $::redis::params::sentinel_init_template,
-  $log_file               = $::redis::params::log_file,
+  $log_file               = $::redis::params::sentinel_log_file,
   $master_name            = $::redis::params::sentinel_master_name,
   $redis_host             = $::redis::params::bind,
   $redis_port             = $::redis::params::port,
@@ -187,12 +186,21 @@ class redis::sentinel (
   $working_dir            = $::redis::params::sentinel_working_dir,
   $notification_script    = $::redis::params::sentinel_notification_script,
   $client_reconfig_script = $::redis::params::sentinel_client_reconfig_script,
+  $discover_master        = $::redis::params::sentinel_discover_master,
+  $members                = $::redis::params::sentinel_members,
+  $multiple_instances     = $::redis::params::sentinel_multiple_instances,
+  $instances              = $::redis::instances,
 ) inherits redis::params {
 
   unless defined(Package[$package_name]) {
     ensure_resource('package', $package_name, {
-      'ensure' => $package_ensure
+      'ensure' => $package_ensure,
+      'provider' => $redis::provider,
     })
+  }
+
+  if $discover_master {
+       $discovered_sentinel_info = template('redis/discover_master.erb')
   }
 
   file {

--- a/templates/discover_master.erb
+++ b/templates/discover_master.erb
@@ -1,0 +1,51 @@
+<%
+##  This erb is actually a script that discovers the sentinel master by making calls to
+##  all the redis::sentinel::members.
+##
+discover_master = @discover_master
+instances = @instances
+discovery = Hash.new()
+if (discover_master && instances) then
+    quorum = @quorum
+    quorum = quorum.to_i
+    instances.sort.each do |instance_name, value|
+        members = @members
+        sentinel_port = @sentinel_port
+        port =  value['port']
+        possible_masters = Array.new()
+        # We will now try to ask all the hosts in the sentinel member list
+        # who do they think the master is
+        members.each do |host|
+           get_sentinel_master_cmd = sprintf("(echo 'sentinel get-master-" +
+                "addr-by-name %s';sleep 0.1) | /usr/bin/nc -w 1 %s %s |  " +
+                "grep -oE '\\b([0-9]{1,3}\.){3}[0-9]{1,3}\\b'", instance_name, host, sentinel_port)
+           res = IO.popen(get_sentinel_master_cmd).read
+           possible_masters.push(res.chomp)
+        end
+        # find Consensus: not the best way, but should work.
+        discovered_sentinel_master = ""
+        uniq_masters = Hash.new 0
+        possible_masters.each do |host|
+            uniq_masters[host] += 1
+        end
+        uniq_masters.each do | master_host, count|
+            if (count >= quorum) then
+                discovered_sentinel_master = master_host
+            end
+        end
+        # At this point in time we should have arrived at a master for this instance
+        if (discovered_sentinel_master != nil && discovered_sentinel_master != "") then
+            master = discovered_sentinel_master
+        else
+        # We default at the first member in case we did not "discover" anything
+            master = members[0]
+        end
+        discovery[instance_name] = Hash.new()
+        discovery[instance_name]['port'] = port
+        discovery[instance_name]['quorum'] = quorum
+        discovery[instance_name]['sentinel_master'] = master
+    end
+end
+require 'json'
+dump = discovery.to_json
+-%><%= dump -%>

--- a/templates/redis-sentinel.conf.erb
+++ b/templates/redis-sentinel.conf.erb
@@ -5,11 +5,46 @@ port <%= @sentinel_port %>
 dir <%= @working_dir %>
 <% if @daemonize -%>daemonize yes<% else -%>daemonize no<% end %>
 pidfile <%= @pid_file %>
-
+<%
+require 'json'
+instances = @instances
+discover_master = @discover_master
+discovered_json = @discovered_sentinel_info
+multiple_instances = @multiple_instances
+if (discover_master && instances && discovered_sentinel_info) then
+    discovered_sentinel_info = JSON.parse(discovered_json)
+    instances.each do |instance_name ,values|
+        port   =  discovered_sentinel_info[instance_name]['port']
+        master =  discovered_sentinel_info[instance_name]['sentinel_master']
+        quorum =  discovered_sentinel_info[instance_name]['quorum']
+-%>
+###############################################################
+sentinel monitor <%= instance_name %> <%= master %> <%= port %> <%= quorum %>
+sentinel down-after-milliseconds <%= instance_name %> <%= @down_after %>
+sentinel parallel-syncs <%= instance_name %> <%= @parallel_sync %>
+sentinel failover-timeout <%= instance_name %> <%= @failover_timeout  %>
+##############################################################
+<%
+    end
+elsif ( instances && multiple_instances ) then
+    instances.each do |instance_name, values|
+        port = values['port']
+-%>
+###############################################################
+sentinel monitor <%= instance_name %> <%= @redis_host %> <%= port %> <%= @quorum %>
+sentinel down-after-milliseconds <%= instance_name %> <%= @down_after %>
+sentinel parallel-syncs <%= instance_name %> <%= @parallel_sync %>
+sentinel failover-timeout <%= instance_name %> <%= @failover_timeout  %>
+##############################################################
+<%
+    end
+else
+-%>
 sentinel monitor <%= @master_name %> <%= @redis_host %> <%= @redis_port %> <%= @quorum %>
 sentinel down-after-milliseconds <%= @master_name %> <%= @down_after %>
 sentinel parallel-syncs <%= @master_name %> <%= @parallel_sync %>
 sentinel failover-timeout <%= @master_name %> <%= @failover_timeout %>
+<% end %>
 <% if @auth_pass -%>
 sentinel auth-pass <%= @master_name %> <%= @auth_pass %>
 <% end -%>

--- a/templates/redis-sentinel.init.redhat.erb
+++ b/templates/redis-sentinel.init.redhat.erb
@@ -1,0 +1,97 @@
+#!/bin/sh
+#
+# redis        init file for starting up the redis-sentinel daemon
+#
+# chkconfig:   - 21 79
+# description: Starts and stops the redis-sentinel daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+name="redis-sentinel"
+exec="/usr/bin/$name"
+shut="/usr/bin/redis-shutdown"
+pidfile="/var/run/redis/sentinel.pid"
+SENTINEL_CONFIG="<%= @config_file %>"
+
+[ -e /etc/sysconfig/redis-sentinel ] && . /etc/sysconfig/redis-sentinel
+
+lockfile=/var/lock/subsys/redis
+
+start() {
+    [ -f $SENTINEL_CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting $name: "
+    daemon --user ${REDIS_USER-redis} "$exec $SENTINEL_CONFIG --daemonize yes --pidfile $pidfile"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $name: "
+    [ -x $shut ] && $shut $name
+    retval=$?
+    if [ -f $pidfile ]
+    then
+        # shutdown haven't work, try old way
+        killproc -p $pidfile $name
+        retval=$?
+    else
+        success "$name shutdown"
+    fi
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    false
+}
+
+rh_status() {
+    status -p $pidfile $name
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -118,6 +118,7 @@ databases <%= @databases %>
 save <%= seconds -%> <%= key_change -%> <%= "\n" -%>
 <%- end -%>
 <% end %>
+
 # By default Redis will stop accepting writes if RDB snapshots are enabled
 # (at least one save point) and the latest background save failed.
 # This will make the user aware (in a hard way) that data is not persisting
@@ -169,7 +170,7 @@ dir <%= @workdir %>
 # different interval, or to listen to another port, and so on.
 #
 # slaveof <masterip> <masterport>
-<% if @slaveof -%>slaveof <%= @slaveof %><% end -%>
+<% if (@slaveof && @slaveof_port) -%>slaveof <%= @slaveof %> <%= @slaveof_port %><% end -%>
 
 # If the master is password protected (using the "requirepass" configuration
 # directive below) it is possible to tell the slave to authenticate before
@@ -719,9 +720,9 @@ activerehashing <% if @activerehashing -%>yes<% else -%>no<% end -%>
 # subscribers and slaves receive data in a push fashion.
 #
 # Both the hard or the soft limit can be disabled just setting it to zero.
-client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit slave 256mb 64mb 60
-client-output-buffer-limit pubsub 32mb 8mb 60
+client-output-buffer-limit normal <%= @client_output_buffer_limit_normal %>
+client-output-buffer-limit slave  <%= @client_output_buffer_limit_slave  %>
+client-output-buffer-limit pubsub <%= @client_output_buffer_limit_pubsub %>
 
 # Redis calls an internal function to perform many background tasks, like
 # closing connections of clients in timeout, purging expired keys that are

--- a/templates/redis.init.erb
+++ b/templates/redis.init.erb
@@ -1,0 +1,90 @@
+#!/bin/sh
+#
+# redis        init file for starting up the redis daemon
+#
+# chkconfig:   - 20 80
+# description: Starts and stops the redis daemon.
+
+# Source function library.
+. /etc/rc.d/init.d/functions
+
+name="<%= @redis_binary_name %>"
+exec="<%= @redis_binary_path %>$name"
+pidfile=<%= @pid_file  %>
+REDIS_CONFIG=<%= @config_file %>
+REDIS_USER='redis'
+
+[ -e /etc/sysconfig/redis ] && . /etc/sysconfig/redis
+
+lockfile=/var/lock/subsys/redis
+
+start() {
+    [ -f $REDIS_CONFIG ] || exit 6
+    [ -x $exec ] || exit 5
+    echo -n $"Starting $name: "
+    daemon --user ${REDIS_USER} "$exec $REDIS_CONFIG"
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && touch $lockfile
+    return $retval
+}
+
+stop() {
+    echo -n $"Stopping $name: "
+    killproc -p $pidfile $name
+    retval=$?
+    echo
+    [ $retval -eq 0 ] && rm -f $lockfile
+    return $retval
+}
+
+restart() {
+    stop
+    start
+}
+
+reload() {
+    false
+}
+
+rh_status() {
+    status -p $pidfile $name
+}
+
+rh_status_q() {
+    rh_status >/dev/null 2>&1
+}
+
+
+case "$1" in
+    start)
+        rh_status_q && exit 0
+        $1
+        ;;
+    stop)
+        rh_status_q || exit 0
+        $1
+        ;;
+    restart)
+        $1
+        ;;
+    reload)
+        rh_status_q || exit 7
+        $1
+        ;;
+    force-reload)
+        force_reload
+        ;;
+    status)
+        rh_status
+        ;;
+    condrestart|try-restart)
+        rh_status_q || exit 0
+        restart
+        ;;
+    *)
+        echo $"Usage: $0 {start|stop|status|restart|condrestart|try-restart}"
+        exit 2
+esac
+exit $?
+


### PR DESCRIPTION
```
Details:
manifests/params.pp
manifests/init.pp
manifests/config.pp
    - $::redis::params::redis_init_template
      $::redis::params::redis_init_file_mode
      $::redis::redis_binary_path
      $::redis::redis_binary_name
      Running multiple instances will give a bunch of redis-server processes, unless the name of the binary has the name of the instance, it becomes very confusing to see what process is running which instance. This makes the output nice. We need to modify the init file in order to pass the instance name to e process name.
       ps: I don't have suse/bsd/debian to test on. this may be wrong for those platforms.

    - $::redis::params::slaveof_port
      Multiple instances run on different ports and need multiple entries for master/slave, thus, we need to move the slave port to be independent of the slave of host. This would need changes in existing configuration. if someone upgrades.

    - $::redis::params::client_output_buffer_limit_normal
      $::redis::params::client_output_buffer_limit_slave
      $::redis::params::client_output_buffer_limit_pubsub
      Made the output buffer limits configurable.

    - $::redis::params::instances
      Takes a hash of instances. All the config variables that can be tuned in config can be passed along with each instance. if nothing is passed. the redis defaults from params and config are observed.

    - $::redis::provider
      Allows one to overload the puppet provider in case you use a different one from the default puppet provider

    - $::redis::params::sentinel_init_template
      template/redis-sentinel.init.redhat.erb
      start-stop-daemon is not a CentOS thing, so we need a Redhat/CentOS specific init script.

manifests/sentinel.pp
    - $::redis::params::sentinel_log_file
      Sentinel needs its own log file and should not write to the same one as redis.

    - $::redis::instances
      Sentinel is configured with multiple instances. the name of sentinel master is the name of the instance.

    - $::redis::sentinel::members
      $::redis::params::sentinel_discover_master
      $::redis::params::sentinel_members
      $::redis::params::sentinel_multiple_instances
      Sentinel configuration is tricky, You can bake who the master is in the configuration, but as the infrastructure lives on, the reality of who the sentinel thinks is the master for an instance changes. With the discovered_master flag you can use a simple .erb script (discover_master.erb) to find out wholl the sentinel think the master is for a given instance. This allows you to reflect the current master in the sentinel configuration. If none of the sentinels are reachable or if the qourem is not reached, it defaults to the first item of $::redis::sentinel::members
```
