### PR TITLE
Add systemd service file template

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,6 +60,9 @@
 #
 #   Default: 0755
 #
+# [*service_file_orig*]
+#   The location and name of a systemd service file
+#
 # [*config_file_orig*]
 #   The location and name of a config file that provides the source
 #   of the redis config file. Two different files are needed
@@ -94,6 +97,11 @@
 #   Define which template to use.
 #
 #   Default: redis/redis.conf.erb
+#
+# [*service_template*]
+#   Define which template to use.
+#
+#   Default: redis/redis.service.erb
 #
 # [*daemonize*]
 #   Have Redis run as a daemon.
@@ -525,11 +533,13 @@ class redis (
   $auto_aof_rewrite_percentage   = $::redis::params::auto_aof_rewrite_percentage,
   $bind                          = $::redis::params::bind,
   $conf_template                 = $::redis::params::conf_template,
+  $service_template              = $::redis::params::service_template,
   $config_dir                    = $::redis::params::config_dir,
   $config_dir_mode               = $::redis::params::config_dir_mode,
   $config_file                   = $::redis::params::config_file,
   $config_file_mode              = $::redis::params::config_file_mode,
   $config_file_orig              = $::redis::params::config_file_orig,
+  $service_file_orig             = $::redis::params::service_file_orig,
   $config_group                  = $::redis::params::config_group,
   $config_owner                  = $::redis::params::config_owner,
   $daemonize                     = $::redis::params::daemonize,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -17,6 +17,7 @@ class redis::params {
   $auto_aof_rewrite_percentage     = 100
   $bind                            = '127.0.0.1'
   $conf_template                   = 'redis/redis.conf.erb'
+  $service_template                = 'redis/redis.service.erb'
   $databases                       = 16
   $dbfilename                      = 'dump.rdb'
   $extra_config_file               = undef
@@ -102,6 +103,8 @@ class redis::params {
       $config_file               = '/etc/redis/redis.conf'
       $config_file_mode          = '0644'
       $config_file_orig          = '/etc/redis/redis.conf.puppet'
+      $service_file_orig         = '/lib/systemd/system/redis.service'
+      $service_file_mode         = '0644'
       $config_group              = 'root'
       $config_owner              = 'redis'
       $daemonize                 = true
@@ -133,6 +136,8 @@ class redis::params {
       $config_file               = '/etc/redis.conf'
       $config_file_mode          = '0644'
       $config_file_orig          = '/etc/redis.conf.puppet'
+      $service_file_orig         = '/lib/systemd/system/redis.service'
+      $service_file_mode         = '0644'
       $config_group              = 'root'
       $config_owner              = 'redis'
       $daemonize                 = true

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -4,6 +4,12 @@
 #
 class redis::service {
   if $::redis::service_manage {
+    file {
+      $::redis::service_file_orig:
+        ensure  => present,
+        content => template($::redis::service_template);
+        mode    => $::redis:service_file_mode
+    }
     service { $::redis::service_name:
       ensure     => $::redis::service_ensure,
       enable     => $::redis::service_enable,

--- a/templates/redis.service.erb
+++ b/templates/redis.service.erb
@@ -1,0 +1,16 @@
+[Unit]
+Description=Redis persistent key-value database
+After=network.target
+
+[Service]
+ExecStartPre=/usr/bin/mkdir -p --mode=<%= @unixsocketperm %> <%= File.dirname(@unixsocket) %>
+ExecStartPre=/usr/bin/chown redis:redis <%= File.dirname(@unixsocket) %>
+ExecStartPre=-/usr/sbin/restorecon -Rv <%= File.dirname(@unixsocket) %>
+ExecStart=/usr/bin/redis-server /etc/redis.conf --daemonize no
+ExecStop=/usr/libexec/redis-shutdown
+User=redis
+Group=redis
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
If the unix socket is configured to be present under a dir in a tmpfs,
like /var/run/redis the directory must be created before launching
redis. The best way to do it is inside service file, ensure the
directory is present (and eventually security context restored) each
time redis is started.