### PR TITLE
Adds redis-server version fact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ Gemfile.lock
 doc
 log/
 pkg
-spec/fixtures
+spec/fixtures/manifests/
+spec/fixtures/modules/
 .bundle/

--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,8 @@ group :test do
   gem 'safe_yaml', '~> 1.0.4',                                      :require => false
   gem 'listen', '<= 3.0.6',                                         :require => false
   gem 'puppet-syntax',                                              :require => false, git: 'https://github.com/gds-operations/puppet-syntax.git'
+  gem 'pry'
+  gem 'rb-readline'
 end
 
 group :system_tests do

--- a/lib/facter/redis_server_version.rb
+++ b/lib/facter/redis_server_version.rb
@@ -1,0 +1,13 @@
+# Fact: redis_server_version
+#
+# Purpose: Retrieve redis-server version if installed
+#
+Facter.add(:redis_server_version) do
+  setcode do
+    if Facter::Util::Resolution.which('redis-server')
+      redis_server_version_output = Facter::Util::Resolution.exec('redis-server -v')
+      # Redis server v=2.8.17 sha=00000000:0 malloc=jemalloc-3.6.0 bits=64 build=4c1d5710660b9479
+      redis_server_version_output.match(/Redis server v=([\w\.]+).+/)[1]
+    end
+  end
+end

--- a/spec/fixtures/facts/redis_server_version
+++ b/spec/fixtures/facts/redis_server_version
@@ -1,0 +1,1 @@
+Redis server v=2.8.19 sha=00000000:0 malloc=jemalloc-3.6.0 bits=64 build=c0359e7aa3798aa2

--- a/spec/unit/collectd_real_version_spec.rb
+++ b/spec/unit/collectd_real_version_spec.rb
@@ -1,0 +1,18 @@
+require 'spec_helper'
+
+describe 'redis_server_version', type: :fact do
+  before { Facter.clear }
+  after { Facter.clear }
+
+  it 'is 2.8.19 according to output' do
+    Facter::Util::Resolution.stubs(:which).with('redis-server').returns('/usr/bin/redis-server')
+    sample_redis_server_version = File.read(fixtures('facts', 'redis_server_version'))
+    Facter::Util::Resolution.stubs(:exec).with('redis-server -v').returns(sample_redis_server_version)
+    expect(Facter.fact(:redis_server_version).value).to eq('2.8.19')
+  end
+
+  it 'is empty string if redis-server not installed' do
+    Facter::Util::Resolution.stubs(:which).with('redis-server').returns(nil)
+    expect(Facter.fact(:redis_server_version).value).to eq(nil)
+  end
+end


### PR DESCRIPTION
* Will be useful in the future to only allow 3.3+ config on newer packages
* Also useful for seeing the version of the redis package easily