### PR TITLE
Fixes ownership issue on Ubuntu

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -103,7 +103,7 @@ class redis::params {
       $config_file               = '/etc/redis/redis.conf'
       $config_file_mode          = '0644'
       $config_file_orig          = '/etc/redis/redis.conf.puppet'
-      $config_group              = 'root'
+
       $config_owner              = 'redis'
       $daemonize                 = true
       $log_dir_mode              = '0755'
@@ -130,10 +130,12 @@ class redis::params {
 
       case $::operatingsystem {
         'Ubuntu': {
+          $config_group              = 'redis'
           # Latest from PPA is 3.0.7
           $minimum_version           = '3.0.7'
         }
         default: {
+          $config_group              = 'root'
           # Debian standard package is 2.4.14
           # But we have dotdeb repo which is 3.2.5
           $minimum_version           = '3.2.5'


### PR DESCRIPTION
* "On Ubuntu 14.04, redis has an init script 
that does chown redis:redis $RUNDIR $PIDFILE 
(where RUNDIR=/var/run/redis and 
PIDFILE=$RUNDIR/redis-server.pid) at startup. 
This causes puppet to "fix" the ownership of 
/var/run/redis (to redis:root unless config_owner 
and config_group have been set differently), 
which triggers a restart of redis-server, 
which changes the ownership of /var/run/redis, 
etc. forever.
* Closes #150