### PR TITLE
Changes for RHEL-ish specific configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,9 @@ bundler_args: --without system_tests
 script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
 matrix:
   fast_finish: true
+  allow_failures:
+    # CentOS 6 has an old version of Redis, requires some future fixes
+    - env: PUPPET_INSTALL_VERSION="1.5.2" PUPPET_INSTALL_TYPE=agent BEAKER_set="centos-6-docker"
   include:
   - rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes" ORDERING="random"
@@ -12,6 +15,12 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
   - rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" ORDERING="random"
+  - rvm: '2.1'
+    sudo: required
+    services: docker
+    env: PUPPET_INSTALL_VERSION="1.5.2" PUPPET_INSTALL_TYPE=agent BEAKER_set="centos-6-docker"
+    script: bundle exec rake acceptance
+    bundler_args: --without development
   - rvm: '2.1'
     sudo: required
     services: docker

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -156,7 +156,7 @@ class redis::params {
       $log_dir_mode              = '0755'
       $package_ensure            = 'present'
       $package_name              = 'redis'
-      $pid_file                  = '/var/run/redis/redis-server.pid'
+      $pid_file                  = '/var/run/redis/redis.pid'
       $sentinel_config_file      = '/etc/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis-sentinel.conf.puppet'
       $sentinel_daemonize        = false
@@ -166,17 +166,31 @@ class redis::params {
       $service_manage            = true
       $service_enable            = true
       $service_ensure            = 'running'
-      $service_group             = 'redis'
       $service_hasrestart        = true
       $service_hasstatus         = true
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
       $workdir                   = '/var/lib/redis/'
-      $workdir_mode              = '0750'
+      $workdir_mode              = '0755'
 
-      # EPEL package is 2.8.19
-      $minimum_version           = '2.8.19'
+      case $::operatingsystemmajrelease {
+        '6': {
+          # CentOS 6 EPEL package is 2.4.10
+          $minimum_version           = '2.4.10'
+
+          $service_group             = 'root'
+        }
+        '7': {
+          # CentOS 7 EPEL package is 3.2.3
+          $minimum_version           = '3.2.3'
+
+          $service_group             = 'redis'
+        }
+        default: {
+          fail("Not sure what Redis version is avaliable upstream on your release: ${::operatingsystemmajrelease}")
+        }
+      }
     }
 
     'FreeBSD': {


### PR DESCRIPTION
* Previously we were changing some of the default 
configurations from the upstream packages
* This causes issues with CentOS 6 services, and 
needlessly clutters logs.
* Change to follow ownership patterns of 
original packages:
  * Changes service group to be root
  * Change workdir permission
  * Change pid file location back to package default
* Adds failing Travis check for CentOS 6