### PR TITLE
Fixes sentinel installation

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -190,11 +190,7 @@ class redis::sentinel (
   $client_reconfig_script = $::redis::params::sentinel_client_reconfig_script,
 ) inherits redis::params {
 
-  unless defined(Package[$package_name]) {
-    ensure_resource('package', $package_name, {
-      'ensure' => $package_ensure
-    })
-  }
+  include ::redis
 
   file {
     $config_file_orig:

--- a/spec/acceptance/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/redis_sentinel_one_node_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper_acceptance'
+
+describe 'redis::sentinel' do
+  case fact('osfamily')
+  when 'Debian'
+    redis_name = 'redis-server'
+  else
+    redis_name = 'redis'
+  end
+
+  it 'should run successfully' do
+    pp = <<-EOS
+
+    $master_name      = 'mymaster'
+    $redis_master     = '127.0.0.1'
+    $failover_timeout = '10000'
+
+    class { 'redis':
+      manage_repo => true,
+    }
+    ->
+    class { 'redis::sentinel':
+      master_name      => $master_name,
+      redis_host       => $redis_master,
+      failover_timeout => $failover_timeout,
+    }
+    EOS
+
+    # Apply twice to ensure no errors the second time.
+    apply_manifest(pp, :catch_failures => true)
+    apply_manifest(pp, :catch_changes => true)
+  end
+
+  describe package(redis_name) do
+    it { should be_installed }
+  end
+
+  describe service(redis_name) do
+    it { should be_running }
+  end
+
+  describe service('redis-sentinel') do
+    it { should be_running }
+  end
+
+  context 'redis should respond to ping command' do
+    describe command('redis-cli ping') do
+      its(:stdout) { should match /PONG/ }
+    end
+  end
+
+  context 'redis-sentinel should return correct sentinel master' do
+    describe command('redis-cli -p 26379 SENTINEL masters') do
+      its(:stdout) { should match /^mymaster/ }
+    end
+  end
+
+end


### PR DESCRIPTION
* When installing sentinel on the same node as redis, duplicate declaration error occurs
* This is because it was originally wrapped in an ensure_resource function
* This was removed in b5174b253b43f75e7dcc2d549b59e272521b93fa
* We should also remove the sentinel ensure_resource
* Instead, include the redis class so we have the variables we need

Should fix #166 