### PR TITLE
Fixes sentinel installation on Debian flavours

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -114,7 +114,7 @@ class redis::params {
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
       $sentinel_daemonize        = true
       $sentinel_init_script      = '/etc/init.d/redis-sentinel'
-      $sentinel_package_name     = 'redis-server'
+      $sentinel_package_name     = 'redis-sentinel'
       $sentinel_package_ensure   = 'present'
       $service_manage            = true
       $service_enable            = true

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -190,10 +190,14 @@ class redis::sentinel (
   $client_reconfig_script = $::redis::params::sentinel_client_reconfig_script,
 ) inherits redis::params {
 
-  unless defined(Package[$package_name]) {
-    ensure_resource('package', $package_name, {
-      'ensure' => $package_ensure
-    })
+  include ::redis
+
+  # Debian flavour machines have a dedicated redis-sentinel package
+  # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775414 for context
+  if $::osfamily == 'Debian' {
+    package { $package_name:
+      ensure => $package_ensure,
+    }
   }
 
   file {

--- a/spec/acceptance/redis_sentinel_one_node_spec.rb
+++ b/spec/acceptance/redis_sentinel_one_node_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper_acceptance'
+
+describe 'redis::sentinel' do
+  case fact('osfamily')
+  when 'Debian'
+    redis_name = 'redis-server'
+  else
+    redis_name = 'redis'
+  end
+
+  it 'should run successfully' do
+    pp = <<-EOS
+
+    $master_name      = 'mymaster'
+    $redis_master     = '127.0.0.1'
+    $failover_timeout = '10000'
+
+    class { 'redis':
+      manage_repo => true,
+    }
+    ->
+    class { 'redis::sentinel':
+      master_name      => $master_name,
+      redis_host       => $redis_master,
+      failover_timeout => $failover_timeout,
+    }
+    EOS
+
+    apply_manifest(pp, :catch_failures => true)
+  end
+
+  describe package(redis_name) do
+    it { should be_installed }
+  end
+
+  describe service(redis_name) do
+    it { should be_running }
+  end
+
+  describe service('redis-sentinel') do
+    it { should be_running }
+  end
+
+  case fact('osfamily')
+  when 'Debian'
+    describe package('redis-sentinel') do
+      it { should be_installed }
+    end
+  end
+
+  context 'redis should respond to ping command' do
+    describe command('redis-cli ping') do
+      its(:stdout) { should match /PONG/ }
+    end
+  end
+
+  context 'redis-sentinel should return correct sentinel master' do
+    describe command('redis-cli -p 26379 SENTINEL masters') do
+      its(:stdout) { should match /^mymaster/ }
+    end
+  end
+
+end


### PR DESCRIPTION
* When installing sentinel on the same node as redis, duplicate
declaration error occurs
* This is because it was originally wrapped in an ensure_resource
* This was removed in b5174b253b43f75e7dcc2d549b59e272521b93fa
* We should also remove the sentinel ensure_resource
* This was originally added because Debian machines have a dedicated
redid-sentinel package, whereas RedHat flavour machines do not
* Instead, include the redis class so we have the variables we need
* Add logic installing the redid-sentinel package on Debian-flavour
* See https://github.com/arioch/puppet-redis/issues/18 for more context