### PR TITLE
Changes permission on /var/run/ directory

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -121,11 +121,20 @@ class redis::config {
         owner  => $::redis::config_owner,
       }
 
+      case $::operatingsystem {
+        'Debian': {
+          $var_run_redis_mode = '2775'
+        }
+        default: {
+          $var_run_redis_mode = '0755'
+        }
+      }
+
       file { '/var/run/redis':
         ensure => 'directory',
         owner  => $::redis::config_owner,
         group  => $::redis::config_group,
-        mode   => '0755',
+        mode   => $var_run_redis_mode,
       }
 
       if $::redis::ulimit {

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -42,7 +42,7 @@ describe 'redis', :type => :class do
                 :ensure => 'directory',
                 :owner  => 'redis',
                 :group  => 'root',
-                :mode   => '0755',
+                :mode   => '2775',
               })
             end
 


### PR DESCRIPTION
* rundir directories are 2775
* e.g.  from the postgres init.d script:
```
 if [ -d /var/run/postgresql ]; then
        chmod 2775 /var/run/postgresql
    else
        install -d -m 2775 -o postgres -g postgres /var/run/postgresql
    fi
```