### PR TITLE
add systemd support for sentinel service

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -641,6 +641,6 @@ class redis (
   exec { 'systemd-reload-redis':
     command     => 'systemctl daemon-reload',
     refreshonly => true,
-    path        => '/bin:/usr/bin:/usr/local/bin'
+    path        => '/bin:/usr/bin:/usr/local/bin',
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -637,4 +637,10 @@ class redis (
       fail "Replication is not possible when binding to ${::redis::bind}."
     }
   }
+
+  exec { 'systemd-reload-redis':
+    command     => 'systemctl daemon-reload',
+    refreshonly => true,
+    path        => '/bin:/usr/bin:/usr/local/bin'
+  }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,6 +29,7 @@ class redis::params {
   $list_max_ziplist_entries        = 512
   $list_max_ziplist_value          = 64
   $log_dir                         = '/var/log/redis'
+  $systemd_override_dir            = '/etc/systemd/system'
   $log_file                        = '/var/log/redis/redis.log'
   $log_level                       = 'notice'
   $maxclients                      = 10000
@@ -58,7 +59,9 @@ class redis::params {
   $sentinel_service_name           = 'redis-sentinel'
   $sentinel_working_dir            = '/tmp'
   $sentinel_init_template          = 'redis/redis-sentinel.init.erb'
+  $sentinel_systemd_template       = 'redis/redis-sentinel.service.erb'
   $sentinel_pid_file               = '/var/run/redis/redis-sentinel.pid'
+  $sentinel_pid_dir                = regsubst($sentinel_pid_file,'^(.*)/[0-9a-z\-_.]+$','\1')
   $sentinel_notification_script    = undef
   $sentinel_client_reconfig_script = undef
   $service_provider                = undef
@@ -110,6 +113,7 @@ class redis::params {
       $package_ensure            = 'present'
       $package_name              = 'redis-server'
       $pid_file                  = '/var/run/redis/redis-server.pid'
+      $pid_dir                   = regsubst($pid_file,'^(.*)/[0-9a-z\-_.]+$','\1')
       $sentinel_config_file      = '/etc/redis/redis-sentinel.conf'
       $sentinel_config_file_orig = '/etc/redis/redis-sentinel.conf.puppet'
       $sentinel_daemonize        = true

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -170,6 +170,7 @@ class redis::sentinel (
   $failover_timeout       = $::redis::params::sentinel_failover_timeout,
   $init_script            = $::redis::params::sentinel_init_script,
   $init_template          = $::redis::params::sentinel_init_template,
+  $systemd_template       = $::redis::params::sentinel_systemd_template,
   $log_file               = $::redis::params::log_file,
   $master_name            = $::redis::params::sentinel_master_name,
   $redis_host             = $::redis::params::bind,
@@ -216,6 +217,19 @@ class redis::sentinel (
       subscribe   => File[$config_file_orig],
       notify      => Service[$service_name],
       refreshonly => true;
+  }
+
+  if ( $facts['service_provider'] == 'systemd' ) {
+    file {
+      "$systemd_override_dir/redis-sentinel.service":
+        ensure  => present,
+        owner   => 'root',
+        group   => 'root',
+        mode    => '0444',
+        content => template($systemd_template),
+        notify  => Exec['systemd-reload-redis'],
+        require => Package[$package_name];
+    }
   }
 
   if $init_script {

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -221,7 +221,7 @@ class redis::sentinel (
 
   if ( $facts['service_provider'] == 'systemd' ) {
     file {
-      "$systemd_override_dir/redis-sentinel.service":
+      "${systemd_override_dir}/redis-sentinel.service":
         ensure  => present,
         owner   => 'root',
         group   => 'root',

--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -221,7 +221,7 @@ class redis::sentinel (
 
   if ( $facts['service_provider'] == 'systemd' ) {
     file {
-      "${systemd_override_dir}/redis-sentinel.service":
+      "${::redis::params::systemd_override_dir}/redis-sentinel.service":
         ensure  => present,
         owner   => 'root',
         group   => 'root',

--- a/templates/redis-sentinel.service.erb
+++ b/templates/redis-sentinel.service.erb
@@ -1,0 +1,37 @@
+[Unit]
+Description=Advanced key-value store
+After=network.target
+Documentation=http://redis.io/documentation, man:redis-sentinel(1)
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/redis-sentinel <%= $config_file %>
+PIDFile= <%= $pid_file %>
+TimeoutStopSec=0
+Restart=always
+User=<%= $service_user %>
+Group=<%= $service_group %>
+
+ExecStartPre=-/bin/run-parts --verbose <%= $config_dir %>/redis-sentinel.pre-up.d
+ExecStartPost=-/bin/run-parts --verbose <%= $config_dir %>/redis-sentinel.post-up.d
+ExecStop=-/bin/run-parts --verbose <%= $config_dir %>/redis-sentinel.pre-down.d
+ExecStop=/bin/kill -s TERM $MAINPID
+ExecStopPost=-/bin/run-parts --verbose <%= $config_dir %>/redis-sentinel.post-down.d
+
+PrivateTmp=yes
+PrivateDevices=yes
+ProtectHome=yes
+ReadOnlyDirectories=/
+ReadWriteDirectories=-<%= $workdir %>
+ReadWriteDirectories=-<%= $log_dir %>
+ReadWriteDirectories=-<%= $redis_pid_dir %>
+CapabilityBoundingSet=~CAP_SYS_PTRACE
+
+# redis-sentinel writes its own config file so we allow writing there (NB.
+# ProtectSystem=true over ProtectSystem=full)
+ProtectSystem=true
+ReadWriteDirectories=-<%= $config_dir %>
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
I based the redis-sentinel service file on Ubuntu's - and made it settable using the params that was already in the module.

It is a bit odd that redis module includes init script for redis-sentinel -but not for redis.
The norm is to NOT include init scripts.. I assume that on some distro's redis-sentinel had no init script, so that would be why it has one for redis-sentinel but not for redis (especiall now that redis-sentinel is part of same redis binary from 3.0+ :)

Looking forward to comments/suggestions - I tried to keep it the same way as the rest of the code.. restraining myself from any puppet-4-isms :)