### PR TITLE
(testing) Simplify command run by TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: ruby
 bundler_args: --without system_tests
-script: "bundle exec rake validate && bundle exec rake lint && bundle exec rake spec SPEC_OPTS='--format documentation'"
+script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
 matrix:
   fast_finish: true
   allow_failures:


### PR DESCRIPTION
Instead of anding all the commands together, we can pass them each to
bundle exec, which achieves the same results.