### PR TITLE
Bump to version 3.0.0

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "arioch-redis",
-  "version": "1.2.4",
+  "version": "3.0.0-RC",
   "author": "Tom De Vylder",
   "summary": "Redis module",
   "license": "Apache-2.0",


### PR DESCRIPTION
This will be the last release that supports
Puppet 3.X

Version 4.x of the module onward will remove 3.X
support