### PR TITLE
Adds logic for managing redis-sentinel package

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -192,11 +192,14 @@ class redis::sentinel (
 
   require ::redis
 
-  # Debian flavour machines have a dedicated redis-sentinel package
-  # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775414 for context
   if $::osfamily == 'Debian' {
-    package { $package_name:
-      ensure => $package_ensure,
+    # Debian flavour machines have a dedicated redis-sentinel package
+    # This is default in Xenial onwards, unstable debian or PPA/other upstream
+    # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775414 for context
+    if (versioncmp($::operatingsystemmajrelease, '16.04') >= 0 or $::redis::manage_repo) {
+      package { $package_name:
+        ensure => $package_ensure,
+      }
     }
   }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -86,8 +86,9 @@ end
 
 def debian_facts
   {
-    :operatingsystem => 'Debian',
-    :osfamily        => 'Debian',
+    :operatingsystem           => 'Debian',
+    :osfamily                  => 'Debian',
+    :operatingsystemmajrelease => '8',
   }
 end
 


### PR DESCRIPTION
* redis-sentinel is present in upstream repos
* It's also present for 16.04/xenial onwards
* So lets only manage that package if we're on
Ubuntu newer or if we're managing the repo