### PR TITLE
Adds redis::administration class

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -9,6 +9,12 @@ fixtures:
     epel:
       repo: 'https://github.com/stahnma/puppet-module-epel.git'
       ref: 1.2.2
+    augeasproviders_sysctl:
+      repo: "git://github.com/hercules-team/augeasproviders_sysctl.git"
+      tag: v2.1.0
+    augeasproviders_core:
+      repo: "git://github.com/hercules-team/augeasproviders_core.git"
+      tag: v2.1.0
   symlinks:
     redis: "#{source_dir}"
 

--- a/manifests/administration.pp
+++ b/manifests/administration.pp
@@ -1,0 +1,47 @@
+# Allows various adminstrative settings for Redis
+# As documented in the FAQ and https://redis.io/topics/admin
+#
+# @example
+#   include redis::administration
+#
+# @example
+#   class {'redis::administration':
+#     disable_thp => false,
+#   }
+#
+# @param [Boolean] enable_overcommit_memory Enable the overcommit memory setting (Defaults to true)
+# @param [Boolean] disable_thp Disable Transparent Huge Pages (Defaults to true)
+# @param [String] somaxconn Set somaxconn value (Defaults to '65535')
+#
+# @author - Peter Souter
+#
+class redis::administration(
+  $enable_overcommit_memory = true,
+  $disable_thp              = true,
+  $somaxconn                = '65535',
+) {
+
+  if $enable_overcommit_memory {
+    sysctl { 'vm.overcommit_memory':
+      ensure => 'present',
+      value  => '1',
+    }
+  }
+
+  if $disable_thp {
+    exec { 'Disable Hugepages':
+      command => 'echo never > /sys/kernel/mm/transparent_hugepage/enabled',
+      path    => ['/sbin', '/usr/sbin', '/bin', '/usr/bin'],
+      onlyif  => 'test -f /sys/kernel/mm/transparent_hugepage/enabled',
+      unless  => 'cat /sys/kernel/mm/transparent_hugepage/enabled | grep "\[never\]"',
+    }
+  }
+
+  if $somaxconn {
+    sysctl { 'net.core.somaxconn':
+      ensure => 'present',
+      value  => $somaxconn,
+    }
+  }
+
+}

--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,15 @@
   "dependencies": [
     {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <3.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.2 <5.0.0"},
-    {"name":"stahnma/epel","version_requirement":">= 1.0.2 <2.0.0"}
+    {"name":"stahnma/epel","version_requirement":">= 1.0.2 <2.0.0"},
+    {
+      "name": "herculesteam/augeasproviders_sysctl",
+      "version_requirement": ">=2.1.0 < 3.0.0"
+    },
+    {
+      "name": "herculesteam/augeasproviders_core",
+      "version_requirement": ">=2.1.0 < 3.0.0"
+    }
   ],
   "data_provider": null,
   "description": "Redis module with cluster support",

--- a/spec/acceptance/redis_adminstration_spec.rb
+++ b/spec/acceptance/redis_adminstration_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper_acceptance'
+
+# systcl settings are untestable in docker
+unless default['hypervisor'] =~ /docker/
+  describe 'redis::administration' do
+    it 'should run successfully' do
+      pp = <<-EOS
+      include redis
+      include redis::administration
+      EOS
+
+      # Apply twice to ensure no errors the second time.
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_changes => true)
+    end
+    it 'should set overcommit_memory to 1 in a seperate sysctl file' do
+      shell('/bin/cat /proc/sys/vm/overcommit_memory') do |result|
+        expect(result.stdout).to match(/^1$/)
+      end
+    end
+    it 'should disable thp' do
+      shell('/bin/cat /sys/kernel/mm/transparent_hugepage/enabled') do |result|
+        expect(result.stdout).to match(/^always madvise \[never\]$/)
+      end
+    end
+    it 'should set somaxconn to 65535' do
+      shell('/bin/cat /proc/sys/net/core/somaxconn') do |result|
+        expect(result.stdout).to match(/^65535$/)
+      end
+    end
+    it 'should show no warnings about kernel settings in logs' do
+      shell('timeout 1s redis-server --port 7777 --loglevel verbose', { :acceptable_exit_codes => [0,124] }) do |result|
+        expect(result.stdout).not_to match(/WARNING/)
+        expect(result.exit_code).to match(124)
+      end
+    end
+  end
+end
+
+

--- a/spec/classes/redis_administration_spec.rb
+++ b/spec/classes/redis_administration_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'redis::administration' do
+  context 'should set kernel and system values' do
+
+    it do
+      is_expected.to contain_sysctl('vm.overcommit_memory').with(
+        {
+          'ensure'=>'present',
+          'value'=>'1'
+        }
+      )
+    end
+
+    it do
+      is_expected.to contain_exec("Disable Hugepages").with(
+        {
+          "command" => "echo never > /sys/kernel/mm/transparent_hugepage/enabled",
+          "path" => ["/sbin", "/usr/sbin", "/bin", "/usr/bin"],
+          "onlyif" => "test -f /sys/kernel/mm/transparent_hugepage/enabled",
+          "unless" => "cat /sys/kernel/mm/transparent_hugepage/enabled | grep \"\\[never\\]\"",
+        }
+      )
+    end
+
+    it do
+      is_expected.to contain_sysctl("net.core.somaxconn").with(
+        {
+          "ensure" => "present",
+          "value" => "65535",
+        }
+      )
+    end
+
+  end
+
+end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -23,6 +23,8 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-stdlib -v 4.11.0'), { :acceptable_exit_codes => [0] }
       on host, puppet('module', 'install', 'puppetlabs-apt -v 2.3.0'), { :acceptable_exit_codes => [0] }
       on host, puppet('module', 'install', 'stahnma-epel -v 1.0.2'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module', 'install', 'herculesteam/augeasproviders_core -v 2.1.0'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module', 'install', 'herculesteam/augeasproviders_sysctl -v 2.1.0'), { :acceptable_exit_codes => [0] }
     end
   end
 end


### PR DESCRIPTION
* Allows modification of common redis kernel
tweaks and requirements
* The ones that antirez (redis creator) mentions
and that are mentioned specifically in redis 
when running it in the logs are:
  * Disable THP: https://redis.io/topics/latency
  * Enable Overcommit Memory: https://redis.io/topics/admin
  * somaxconnL http://download.redis.io/redis-stable/redis.conf