### PR TITLE
Improves ulimit configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,21 @@
 language: ruby
 bundler_args: --without system_tests
 script: 'SPEC_OPTS="--format documentation" bundle exec rake validate lint spec'
+before_install:
+  - gem install bundler # -v x.x.x if a specific version is needed
 matrix:
   fast_finish: true
   include:
   - sudo: required
-    dist: precise
+    dist: trusty
     rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes" ORDERING="random"
   - sudo: required
-    dist: precise
+    dist: trusty
     rvm: 2.0.0
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
   - sudo: required
-    dist: precise
+    dist: trusty
     rvm: 2.1.9
     env: PUPPET_GEM_VERSION="~> 4.0" STRICT_VARIABLES="yes" ORDERING="random"
   - sudo: required

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -115,6 +115,10 @@ class redis::config {
     owner  => $::redis::service_user,
   }
 
+  if $::redis::ulimit {
+    contain ::redis::ulimit
+  }
+
   exec {"cp -p ${::redis::config_file_orig} ${::redis::config_file}":
     path        => '/usr/bin:/bin',
     subscribe   => File[$::redis::config_file_orig],
@@ -147,12 +151,6 @@ class redis::config {
         mode   => $var_run_redis_mode,
       }
 
-      if $::redis::ulimit {
-        augeas { 'redis ulimit' :
-          context => '/files/etc/default/redis-server',
-          changes => "set ULIMIT ${::redis::ulimit}",
-        }
-      }
     }
 
     default: {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -175,10 +175,17 @@
 #
 #   Default: false
 #
+#
 # [*manage_package*]
 #   Enable/disable management of package
 #
 #   Default: true
+#
+# [managed_by_cluster_manager]
+#   Choose if redis will be managed by a cluster manager
+#   such as pacemaker or rgmanager
+#
+#   Default: false
 #
 # [*masterauth*]
 #   If the master is password protected (using the "requirepass" configuration
@@ -569,6 +576,7 @@ class redis (
   $no_appendfsync_on_rewrite     = $::redis::params::no_appendfsync_on_rewrite,
   $notify_keyspace_events        = $::redis::params::notify_keyspace_events,
   $notify_service                = $::redis::params::notify_service,
+  $managed_by_cluster_manager    = $::redis::params::managed_by_cluster_manager,
   $package_ensure                = $::redis::params::package_ensure,
   $package_name                  = $::redis::params::package_name,
   $pid_file                      = $::redis::params::pid_file,
@@ -637,4 +645,11 @@ class redis (
       fail "Replication is not possible when binding to ${::redis::bind}."
     }
   }
+
+  exec { 'systemd-reload-redis':
+    command     => 'systemctl daemon-reload',
+    refreshonly => true,
+    path        => '/bin:/usr/bin:/usr/local/bin',
+  }
+
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -4,8 +4,9 @@
 #
 class redis::params {
   # Generic
-  $manage_repo = false
-  $manage_package = true
+  $manage_repo                = false
+  $manage_package             = true
+  $managed_by_cluster_manager = false
 
   # redis.conf.erb
   $activerehashing                 = true

--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -1,0 +1,77 @@
+# Redis class for configuring ulimit
+# Used to DRY up the config class, and
+# move the logic for ulimit changes all
+# into one place.
+#
+# Parameters are not required as it's a
+# private class only referencable from
+# the redis module, where the variables
+# would already be defined
+#
+# @example
+#   contain redis::ulimit
+#
+# @author - Peter Souter
+#
+# @api private
+class redis::ulimit {
+  assert_private('The redis::ulimit class is only to be called from the redis::config class')
+
+  $service_provider_lookup = pick(getvar_emptystring('service_provider'), false)
+
+  if $::redis::managed_by_cluster_manager {
+    file { '/etc/security/limits.d/redis.conf':
+      ensure  => 'file',
+      owner   => 'root',
+      group   => 'root',
+      mode    => '0644',
+      content => "redis soft nofile ${::redis::ulimit}\nredis hard nofile ${::redis::ulimit}\n",
+    }
+  }
+  if $service_provider_lookup == 'systemd' {
+    file { "/etc/systemd/system/${::redis::service_name}.service.d/":
+      ensure => 'directory',
+      owner  => 'root',
+      group  => 'root',
+    }
+
+    file { "/etc/systemd/system/${::redis::service_name}.service.d/limit.conf":
+      ensure => file,
+      owner  => 'root',
+      group  => 'root',
+      mode   => '0444',
+    }
+    augeas { 'Systemd redis ulimit' :
+      incl    => "/etc/systemd/system/${::redis::service_name}.service.d/limits.conf",
+      lens    => 'Systemd.lns',
+      context => "/etc/systemd/system/${::redis::service_name}.service.d/limits.conf",
+      changes => [
+        "defnode nofile Service/LimitNOFILE \"\"",
+        "set \$nofile/value \"${::redis::ulimit}\""],
+      notify  => [
+        Exec['systemd-reload-redis'],
+        Service[$::redis::service_name]
+      ],
+    }
+  } else {
+    augeas { 'redis ulimit':
+      changes => "set ULIMIT ${::redis::ulimit}",
+    }
+    case $::osfamily {
+      'Debian': {
+        Augeas['redis ulimit'] {
+          context => '/files/etc/default/redis-server',
+        }
+      }
+      'RedHat': {
+        Augeas['redis ulimit'] {
+          context => '/files/etc/sysconfig/redis',
+        }
+      }
+      default: {
+        warning("Not sure how to set ULIMIT on non-systemd OSFamily ${::osfamily}, PR's welcome")
+      }
+    }
+  }
+
+}

--- a/spec/acceptance/nodesets/ubuntu-1604-x64.yml
+++ b/spec/acceptance/nodesets/ubuntu-1604-x64.yml
@@ -1,0 +1,10 @@
+HOSTS:
+  ubuntu-1604-x64:
+    roles:
+      - default
+    platform: ubuntu-1604-amd64
+    box: puppetlabs/ubuntu-16.04-64-nocm
+    hypervisor: vagrant
+CONFIG:
+  log_level: debug
+  type: foss

--- a/spec/classes/redis_ulimit_spec.rb
+++ b/spec/classes/redis_ulimit_spec.rb
@@ -1,0 +1,132 @@
+require 'spec_helper'
+
+describe 'redis::ulimit' do
+  # add these two lines in a single test block to enable puppet and hiera debug mode
+  # Puppet::Util::Log.level = :debug
+  # Puppet::Util::Log.newdestination(:console)
+
+  context 'with managed_by_cluster_manager true' do
+    let(:facts) {
+      debian_facts
+    }
+    let :pre_condition do
+      [
+        'class { redis:
+          managed_by_cluster_manager => true,
+        }'
+      ]
+    end
+    it do
+      is_expected.to contain_file("/etc/security/limits.d/redis.conf").with(
+        {
+          "ensure"  => "file",
+          "owner"   => "root",
+          "group"   => "root",
+          "mode"    => "0644",
+          "content" => "redis soft nofile 65536\nredis hard nofile 65536\n",
+        }
+      )
+    end
+  end
+
+  context 'on a systemd system' do
+    let(:facts) {
+      debian_facts.merge({
+        :service_provider => 'systemd',
+      })
+    }
+    let :pre_condition do
+      [
+        'class { redis:
+          ulimit => "7777",
+        }'
+      ]
+    end
+    it do
+      is_expected.to contain_file("/etc/systemd/system/redis-server.service.d/limit.conf").with(
+      {
+        "ensure" => "file",
+        "owner"  => "root",
+        "group"  => "root",
+        "mode"   => "0444",
+      }
+      )
+    end
+
+    it do
+      is_expected.to contain_augeas("Systemd redis ulimit").with(
+      {
+        'incl'     => '/etc/systemd/system/redis-server.service.d/limits.conf',
+        'lens'     => 'Systemd.lns',
+        'context'  => '/etc/systemd/system/redis-server.service.d/limits.conf',
+        'changes'  => [
+          "defnode nofile Service/LimitNOFILE \"\"",
+          "set $nofile/value \"7777\""
+        ],
+        'notify'   => [
+          'Exec[systemd-reload-redis]',
+          'Service[redis-server]'
+          ],
+        }
+        )
+    end
+  end
+
+  context 'on a non-systemd system' do
+    context 'Ubuntu 1404 system' do
+      let(:facts) {
+        ubuntu_1404_facts.merge({
+          :service_provider => 'debian',
+        })
+      }
+      let :pre_condition do
+        [
+          'class { redis:
+            ulimit => "7777",
+          }'
+        ]
+      end
+      it do
+        is_expected.not_to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf')
+      end
+
+      it do
+        is_expected.not_to contain_augeas('Systemd redis ulimit')
+      end
+
+      it do
+        is_expected.to contain_augeas('redis ulimit').with('changes' => 'set ULIMIT 7777')
+        is_expected.to contain_augeas('redis ulimit').with('context' => '/files/etc/default/redis-server')
+      end
+    end
+
+    context 'CentOS 6 system' do
+      let(:facts) {
+        centos_6_facts.merge({
+          :service_provider => 'redhat',
+        })
+      }
+      let :pre_condition do
+        [
+          'class { redis:
+            ulimit => "7777",
+          }'
+        ]
+      end
+      it do
+        is_expected.not_to contain_file('/etc/systemd/system/redis-server.service.d/limit.conf')
+      end
+
+      it do
+        is_expected.not_to contain_augeas('Systemd redis ulimit')
+      end
+
+      it do
+        is_expected.to contain_augeas('redis ulimit').with('changes' => 'set ULIMIT 7777')
+        is_expected.to contain_augeas('redis ulimit').with('context' => '/files/etc/sysconfig/redis')
+      end
+    end
+  end
+
+
+end


### PR DESCRIPTION
* Moves to a dedicated class to DRY up config.pp
* Adds support for systemd systems:
 - /etc/systemd/system/redis.service.d/limit.conf
* Add support for redis when used with a cluster
manager such as pacemaker or rgmanager
* New parameter `managed_by_cluster_manager`
* This manages the file under:
```
/etc/security/limits.d/redis.conf
```
* Closes #130