### PR TITLE
Specify sort key in redis.conf.erb

### DIFF
--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -114,7 +114,7 @@ databases <%= @databases %>
 #
 #   save ""
 <% if @save_db_to_disk %>
-<%- @save_db_to_disk_interval.sort_by{}.each do |seconds, key_change| -%>
+<%- @save_db_to_disk_interval.sort_by{|k,v|k}.each do |seconds, key_change| -%>
 save <%= seconds -%> <%= key_change -%> <%= "\n" -%>
 <%- end -%>
 <% end %>


### PR DESCRIPTION
This adds Ruby 1.8 compatibility which was lost in v1.2.4