### PR TITLE
Update sort to specify key

### DIFF
--- a/templates/redis.conf.2.4.10.erb
+++ b/templates/redis.conf.2.4.10.erb
@@ -84,7 +84,7 @@ databases <%= @databases %>
 #
 #   Note: you can disable saving at all commenting all the "save" lines.
 <% if @save_db_to_disk %>
-<%- @save_db_to_disk_interval.sort_by{}.each do |seconds, key_change| -%>
+<%- @save_db_to_disk_interval.sort_by{|k,v|k}.each do |seconds, key_change| -%>
 save <%= seconds -%> <%= key_change -%> <%= "\n" -%>
 <%- end -%>
 <% end %>

--- a/templates/redis.conf.2.8.erb
+++ b/templates/redis.conf.2.8.erb
@@ -152,7 +152,7 @@ databases <%= @databases %>
 #
 #   save ""
 <% if @save_db_to_disk %>
-<%- @save_db_to_disk_interval.sort_by{}.each do |seconds, key_change| -%>
+<%- @save_db_to_disk_interval.sort_by{|k,v|k}.each do |seconds, key_change| -%>
 save <%= seconds -%> <%= key_change -%> <%= "\n" -%>
 <%- end -%>
 <% end %>

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -114,7 +114,7 @@ databases <%= @databases %>
 #
 #   save ""
 <% if @save_db_to_disk %>
-<%- @save_db_to_disk_interval.sort_by{}.each do |seconds, key_change| -%>
+<%- @save_db_to_disk_interval.sort_by{|k,v|k}.each do |seconds, key_change| -%>
 save <%= seconds -%> <%= key_change -%> <%= "\n" -%>
 <%- end -%>
 <% end %>


### PR DESCRIPTION
* With the previous approach, error on 1.8.7 Ruby:
```
Error: Failed to parse template redis/redis.conf.2.4.10.erb:
  Filepath: /etc/puppet/modules/redis/templates/redis.conf.2.4.10.erb
  Line: 87
  Detail: undefined method `<=>' for nil:NilClass
 at /etc/puppet/modules/redis/manifests/config.pp:91 on node master
```
* For ruby 1.8 compatibility
* Should fix older Puppet on systems that have 
1.8.7 Ruby (RHEL6/CentOS6)
* We're not officially supporting 1.8.7 as it's 
EOL, but since this is a minor change, isn't too 
much of a maintenance cost, lets do it! :dancer: