### PR TITLE
Ignore selinux default context for /etc/systemd/system/redis.service.d

### DIFF
--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -30,9 +30,10 @@ class redis::ulimit {
   }
   if $service_provider_lookup == 'systemd' {
     file { "/etc/systemd/system/${::redis::service_name}.service.d/":
-      ensure => 'directory',
-      owner  => 'root',
-      group  => 'root',
+      ensure                  => 'directory',
+      owner                   => 'root',
+      group                   => 'root',
+      selinux_ignore_defaults => true,
     }
 
     file { "/etc/systemd/system/${::redis::service_name}.service.d/limit.conf":


### PR DESCRIPTION
When creating new files/directory/symlink, puppet asumes that it's a file
to get the default context. This is wrong as the default context depends
on the file type. See https://tickets.puppetlabs.com/browse/PUP-7559

For the redis case, when creating /etc/systemd/system/redis.service.d
it's setting the context redis_unit_file_t, which is wrong. It should
be systemd_unit_file_t. This has two efects, it's setting the directory
to a wrong context on first run and it's breaking the idempotency of
puppet-redis.

With this patch, puppet-redis is ignoring selinux context for the directory.
Note that the default context is applied automatically by the OS, so it
will be set to the right one.