### PR TITLE
Add switch to manage File[/var/run/redis] on debian systems

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -135,20 +135,22 @@ class redis::config {
         owner  => $::redis::config_owner,
       }
 
-      case $::operatingsystem {
-        'Debian': {
-          $var_run_redis_mode = '2775'
+      if $::redis::manage_var_run_dir {
+        case $::operatingsystem {
+          'Debian': {
+            $var_run_redis_mode = '2775'
+          }
+          default: {
+            $var_run_redis_mode = '0755'
+          }
         }
-        default: {
-          $var_run_redis_mode = '0755'
-        }
-      }
 
-      file { '/var/run/redis':
-        ensure => 'directory',
-        owner  => $::redis::config_owner,
-        group  => $::redis::config_group,
-        mode   => $var_run_redis_mode,
+        file { '/var/run/redis':
+          ensure => 'directory',
+          owner  => $::redis::config_owner,
+          group  => $::redis::config_group,
+          mode   => $var_run_redis_mode,
+        }
       }
 
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -520,6 +520,11 @@
 #
 #   Default: 5000
 #
+# [*manage_var_run_dir*]
+#   Manage /var/run/dir on debian systems.
+#
+#   Default: true
+#
 # == Actions:
 #   - Install and configure Redis
 #
@@ -623,6 +628,7 @@ class redis (
   $cluster_enabled               = $::redis::params::cluster_enabled,
   $cluster_config_file           = $::redis::params::cluster_config_file,
   $cluster_node_timeout          = $::redis::params::cluster_node_timeout,
+  $manage_var_run_dir            = $::redis::params::manage_var_run_dir,
 ) inherits redis::params {
 
   contain ::redis::preinstall

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,6 +128,7 @@ class redis::params {
       $ppa_repo                  = 'ppa:chris-lea/redis-server'
       $workdir                   = '/var/lib/redis/'
       $workdir_mode              = '0750'
+      $manage_var_run_dir        = true
 
       case $::operatingsystem {
         'Ubuntu': {


### PR DESCRIPTION
The existence of /var/run/redis causes the startup of redis-server via
systemd to fail on debian systems with redis-server >= 3.2.8-2.

The default unit file for redis-server in debian jessie-backports
contains `RuntimeDirectory=redis`, see [this commit](https://github.com/lamby/pkg-redis/commit/1cecea5abcb2ce05beacd4347977634d06c59cef).

This causes systemd to attempt to create `/var/run/redis`, which fails,
since puppet already created it:

```
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Starting Advanced key-value store...
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[24311]: Failed at step RUNTIME_DIRECTORY spawning /bin/run-parts: File exists
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[24312]: Failed at step RUNTIME_DIRECTORY spawning /usr/bin/redis-server: File exists
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: redis-server.service: control process exited, code=exited status=233
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Failed to start Advanced key-value store.
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Unit redis-server.service entered failed state.
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: redis-server.service holdoff time over, scheduling restart.
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Stopping Advanced key-value store...
```

Additionally the `$var_run_redis_mode` is wrong as well, since redis-server
sets it to `0755` and the module changes it back to `2755`.

Also see issue #150, the same applies here - puppet changes the mode of
`/var/run/dir` and refreshes `Service[redis-server]`, which then fails
to restart because systemd can't create the directory.
