### PR TITLE
Add switch to manage File[/var/run/redis]

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -135,20 +135,24 @@ class redis::config {
         owner  => $::redis::config_owner,
       }
 
-      case $::operatingsystem {
-        'Debian': {
-          $var_run_redis_mode = '2775'
-        }
-        default: {
-          $var_run_redis_mode = '0755'
-        }
-      }
+      $service_provider_lookup = pick(getvar_emptystring('service_provider'), false)
 
-      file { '/var/run/redis':
-        ensure => 'directory',
-        owner  => $::redis::config_owner,
-        group  => $::redis::config_group,
-        mode   => $var_run_redis_mode,
+      if $service_provider_lookup != 'systemd' {
+        case $::operatingsystem {
+          'Debian': {
+            $var_run_redis_mode = '2775'
+          }
+          default: {
+            $var_run_redis_mode = '0755'
+          }
+        }
+
+        file { '/var/run/redis':
+          ensure => 'directory',
+          owner  => $::redis::config_owner,
+          group  => $::redis::config_group,
+          mode   => $var_run_redis_mode,
+        }
       }
 
     }

--- a/spec/acceptance/redis_debian_run_dir_spec.rb
+++ b/spec/acceptance/redis_debian_run_dir_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper_acceptance'
+
+# since this test polutes others, we'll only run it if specifically asked
+if ENV['RUN_BACKPORT_TEST'] == 'yes'
+  describe 'redis', :if => (fact('operatingsystem') == 'Debian') do
+    it 'should run with newer Debian package' do
+      pp = <<-EOS
+
+      include ::apt
+
+      class {'::apt::backports':}
+      ->
+      file { '/usr/sbin/policy-rc.d':
+        ensure  => present,
+        content => "/usr/bin/env sh\nexit 101",
+        mode    => '0755',
+      }
+      ->
+      package { 'redis-server':
+        ensure => 'latest',
+        install_options => {
+          '-t' => "${::lsbdistcodename}-backports",
+        },
+      }
+      ->
+      class { 'redis':
+        manage_package => false,
+      }
+      EOS
+
+      apply_manifest(pp, :catch_failures => true)
+      apply_manifest(pp, :catch_change   => true)
+    end
+
+    describe package('redis-server') do
+      it { should be_installed }
+    end
+
+    describe service('redis-server') do
+      it { should be_running }
+    end
+
+    context 'redis should respond to ping command' do
+      describe command('redis-cli ping') do
+        its(:stdout) { should match /PONG/ }
+      end
+    end
+
+    context 'redis log should be clean' do
+      describe command('journalctl --no-pager') do
+        its(:stdout) { should_not match /Failed at step RUNTIME_DIRECTORY/ }
+      end
+    end
+  end
+end


### PR DESCRIPTION
The existence of /var/run/redis causes the startup of redis-server via
systemd to fail on debian systems with redis-server >= 3.2.8-2.

The default unit file for redis-server in debian jessie-backports
contains `RuntimeDirectory=redis`, see [this commit](https://github.com/lamby/pkg-redis/commit/1cecea5abcb2ce05beacd4347977634d06c59cef).

This causes systemd to attempt to create `/var/run/redis`, which fails,
since puppet already created it:

```
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Starting Advanced key-value store...
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[24311]: Failed at step RUNTIME_DIRECTORY spawning /bin/run-parts: File exists
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[24312]: Failed at step RUNTIME_DIRECTORY spawning /usr/bin/redis-server: File exists
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: redis-server.service: control process exited, code=exited status=233
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Failed to start Advanced key-value store.
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Unit redis-server.service entered failed state.
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: redis-server.service holdoff time over, scheduling restart.
May 18 14:12:12 po-redis-gitlab-qa-bs01 systemd[1]: Stopping Advanced key-value store...
```

Additionally the `$var_run_redis_mode` is wrong as well, since redis-server
sets it to `0755` and the module changes it back to `2755`.

Also see issue #150, the same applies here - puppet changes the mode of
`/var/run/dir` and refreshes `Service[redis-server]`, which then fails
to restart because systemd can't create the directory.
