### PR TITLE
Refactor redisget() method

### DIFF
--- a/lib/puppet/parser/functions/redisget.rb
+++ b/lib/puppet/parser/functions/redisget.rb
@@ -34,20 +34,12 @@ DOC
     raise(Puppet::ParseError, "redisget(): Wrong argument type given (#{url.class} for String) for arg2 (url)") if url.is_a?(String) == false
 
     begin
-      redis = Redis.new(:url => url)
-      returned_value = redis.get(key)
-      if returned_value == nil and defined?(default) != nil
-        default
-      else
-        returned_value
-      end
-    rescue Exception => e
-      if default
-        debug "Connection to redis failed with #{e} - Returning default value of #{default}"
-        default
-      else
-        raise(Puppet::Error, "connection to redis server failed - #{e}")
-      end
+      Redis.new(:url => url).get(key) || default
+    rescue Redis::CannotConnectError, SocketError => e
+      raise Puppet::Error, "connection to redis server failed - #{e}" unless default
+      debug "Connection to redis failed with #{e} - Returning default value of #{default}"
+      default
     end
+
   end
 end

--- a/spec/functions/redisget_spec.rb
+++ b/spec/functions/redisget_spec.rb
@@ -3,15 +3,24 @@ require 'mock_redis'
 require 'redis'
 
 REDIS_URL='redis://localhost:6379'
-BROKEN_URL='redis://redis.example.com:1234'
+LOCAL_BROKEN_URL='redis://localhost:1234'
+REMOTE_BROKEN_URL='redis://redis.example.com:1234'
 
 describe 'redisget' do
-  context 'should error if connection to redis server cannot be made and no default is specified' do
-    it { is_expected.to run.with_params('nonexistent_key', BROKEN_URL).and_raise_error(Puppet::Error, /connection to redis server failed - getaddrinfo/) }
+  context 'should error if connection to remote redis server cannot be made and no default is specified' do
+    it { is_expected.to run.with_params('nonexistent_key', REMOTE_BROKEN_URL).and_raise_error(Puppet::Error, /connection to redis server failed - getaddrinfo/) }
   end
 
-  context 'should return default value if connection to redis server cannot be made and default is specified' do
-    it { is_expected.to run.with_params('nonexistent_key', BROKEN_URL, 'default_value').and_return('default_value') }
+  context 'should return default value if connection to remote redis server cannot be made and default is specified' do
+    it { is_expected.to run.with_params('nonexistent_key', REMOTE_BROKEN_URL, 'default_value').and_return('default_value') }
+  end
+
+  context 'should error if connection to local redis server cannot be made and no default is specified' do
+    it { is_expected.to run.with_params('nonexistent_key', LOCAL_BROKEN_URL).and_raise_error(Puppet::Error, /connection to redis server failed - Error connecting to Redis on localhost:1234/) }
+  end
+
+  context 'should return default value if connection to local redis server cannot be made and default is specified' do
+    it { is_expected.to run.with_params('nonexistent_key', LOCAL_BROKEN_URL, 'default_value').and_return('default_value') }
   end
 
   context 'should return nil if key does not exist and no default is specified' do


### PR DESCRIPTION
* The original behaviour seemed a little brittle to me, so I asked for some help
* This new refactor seems a lot cleaner, and deals with the handling of getting a nil response a lot cleaner
* Specs edited to add in two types of disconnection errors: getaddrinfo for non-existent DNS and ECONNREFUSED for when connection refused
* Credit: https://codereview.stackexchange.com/questions/163727/redis-lookup-with-a-default-value/