### PR TITLE
Update EPEL module

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -10,7 +10,7 @@
   "dependencies": [
     {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <3.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.2 <5.0.0"},
-    {"name":"stahnma/epel","version_requirement":">= 1.0.2 <2.0.0"},
+    {"name":"stahnma/epel","version_requirement":">= 1.2.2 <2.0.0"},
     {
       "name": "herculesteam/augeasproviders_sysctl",
       "version_requirement": ">=2.1.0 < 3.0.0"

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -22,7 +22,7 @@ RSpec.configure do |c|
       end
       on host, puppet('module', 'install', 'puppetlabs-stdlib -v 4.11.0'), { :acceptable_exit_codes => [0] }
       on host, puppet('module', 'install', 'puppetlabs-apt -v 2.3.0'), { :acceptable_exit_codes => [0] }
-      on host, puppet('module', 'install', 'stahnma-epel -v 1.0.2'), { :acceptable_exit_codes => [0] }
+      on host, puppet('module', 'install', 'stahnma-epel -v 1.2.2'), { :acceptable_exit_codes => [0] }
       on host, puppet('module', 'install', 'herculesteam/augeasproviders_core -v 2.1.0'), { :acceptable_exit_codes => [0] }
       on host, puppet('module', 'install', 'herculesteam/augeasproviders_sysctl -v 2.1.0'), { :acceptable_exit_codes => [0] }
     end


### PR DESCRIPTION
* Fixes endpoints to be https
* Fixed a long time ago (https://github.com/stahnma/puppet-module-epel/issues/34)
* Updates spec_helper_acceptance and metadata