### PR TITLE
Use package_ensure if it specifies a version instead of the minimum_version

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -161,6 +161,7 @@ define redis::instance(
   $no_appendfsync_on_rewrite     = $::redis::no_appendfsync_on_rewrite,
   $notify_keyspace_events        = $::redis::notify_keyspace_events,
   $managed_by_cluster_manager    = $::redis::managed_by_cluster_manager,
+  $package_ensure                = $::redis::package_ensure,
   $port                          = $::redis::port,
   $rdbcompression                = $::redis::rdbcompression,
   $repl_backlog_size             = $::redis::repl_backlog_size,
@@ -276,7 +277,11 @@ define redis::instance(
     refreshonly => true,
   }
 
-  $redis_version_real = pick(getvar_emptystring('redis_server_version'), $minimum_version)
+  if $package_ensure =~ /^[0-9]+\.[0-9]/ {
+    $redis_version_real = $package_ensure
+  } else {
+    $redis_version_real = pick(getvar_emptystring('redis_server_version'), $minimum_version)
+  }
 
   if ($redis_version_real and $conf_template == 'redis/redis.conf.erb') {
     case $redis_version_real {

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -24,6 +24,36 @@ describe 'redis' do
 
       end
 
+      context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
+
+        let(:facts) {
+          centos_6_facts.merge({
+            :redis_server_version => nil,
+            :puppetversion        => Puppet.version,
+          })
+        }
+        let (:params) { { :package_ensure => '3.2.1' } }
+
+        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+      end
+
+      context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
+
+        let(:facts) {
+          centos_6_facts.merge({
+            :redis_server_version => nil,
+            :puppetversion        => Puppet.version,
+          })
+        }
+        let (:params) { { :package_ensure => '4.0-rc3' } }
+
+        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+      end
+
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
 
         let(:facts) {

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -22,6 +22,34 @@ describe 'redis' do
 
       end
 
+      context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
+
+        let(:facts) {
+          ubuntu_1404_facts.merge({
+            :redis_server_version => nil,
+          })
+        }
+        let (:params) { { :package_ensure => '3.2.1' } }
+
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+
+      end
+
+      context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
+
+        let(:facts) {
+          ubuntu_1404_facts.merge({
+            :redis_server_version => nil,
+          })
+        }
+        let (:params) { { :package_ensure => '4.0-rc3' } }
+
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+
+      end
+
       context 'when $::redis_server_version fact is present but the older version (older features not enabled)' do
 
         let(:facts) {


### PR DESCRIPTION
When using package_ensure => some_version, it will initially configure the the redis using the minimum_version variable anyway instead of taking in account the package_ensure variable. This PR fixes that.