### PR TITLE
Split the redis instance logfiles by default

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -32,6 +32,7 @@ class redis::config {
   if $::redis::default_install {
     redis::instance {'default':
       pid_file            => $::redis::pid_file,
+      log_file            => $::redis::log_file,
       manage_service_file => $::redis::manage_service_file,
     }
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -148,7 +148,6 @@ define redis::instance(
   $latency_monitor_threshold     = $::redis::latency_monitor_threshold,
   $list_max_ziplist_entries      = $::redis::list_max_ziplist_entries,
   $list_max_ziplist_value        = $::redis::list_max_ziplist_value,
-  $log_file                      = $::redis::log_file,
   $log_level                     = $::redis::log_level,
   $minimum_version               = $::redis::minimum_version,
   $masterauth                    = $::redis::masterauth,
@@ -200,6 +199,7 @@ define redis::instance(
   $service_hasstatus             = $::redis::service_hasstatus,
   # Defaults for redis::instance
   $manage_service_file           = true,
+  $log_file                      = "/var/log/redis/redis-server-${name}.log",
   $pid_file                      = "/var/run/redis/redis-server-${name}.pid",
 ) {
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -16,6 +16,7 @@ describe 'redis::instance', :type => :define do
           ubuntu_1404_facts
         }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
+	it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis.conf.redis2/) }
         it { should contain_file('/etc/init.d/redis2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-redis2.pid/) }
@@ -27,6 +28,7 @@ describe 'redis::instance', :type => :define do
           })
         }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
+	it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis.conf.redis2/) }
       end
@@ -37,6 +39,7 @@ describe 'redis::instance', :type => :define do
           centos_6_facts
         }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
+	it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/REDIS_CONFIG="\/etc\/redis.conf.redis2"/) }
         it { should contain_file('/etc/init.d/redis2').with_content(/pidfile="\/var\/run\/redis\/redis-server-redis2.pid"/) }
@@ -48,6 +51,7 @@ describe 'redis::instance', :type => :define do
           })
         }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
+	it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis.conf.redis2/) }
       end


### PR DESCRIPTION
Avoid the logs of multiple instances going into the default log file without the user having to define a separate log file for each instance