### PR TITLE
fix package_ensure version on ubuntu when it is in the 3:3.2.1 format

### DIFF
--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -277,8 +277,13 @@ define redis::instance(
     refreshonly => true,
   }
 
-  if $package_ensure =~ /^[0-9]+\.[0-9]/ {
-    $redis_version_real = $package_ensure
+  if $package_ensure =~ /^([0-9]+:)?[0-9]+\.[0-9]/ {
+    if ':' in $package_ensure {
+      $_redis_version_real = split($package_ensure, ':')
+      $redis_version_real = $_redis_version_real[1]
+    } else {
+      $redis_version_real = $package_ensure
+    }
   } else {
     $redis_version_real = pick(getvar_emptystring('redis_server_version'), $minimum_version)
   }

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -36,6 +36,33 @@ describe 'redis' do
 
       end
 
+      context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3:3.2.1) (older features enabled)' do
+
+        let(:facts) {
+          ubuntu_1404_facts.merge({
+            :redis_server_version => nil,
+          })
+        }
+        let (:params) { { :package_ensure => '3:3.2.1' } }
+
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+
+      end
+
+      context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4:4.0-rc3) (older features enabled)' do
+
+        let(:facts) {
+          ubuntu_1404_facts.merge({
+            :redis_server_version => nil,
+          })
+        }
+        let (:params) { { :package_ensure => '4:4.0-rc3' } }
+
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+
+      end
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(4.0-rc3) (older features enabled)' do
 
         let(:facts) {


### PR DESCRIPTION
After merging #215 I found that on Ubuntu sometimes the version of the package is in the 3:3.2.1 format (instead of being 3.2.1). This PR will take care of this.