### PR TITLE
Split Redis workdir

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,6 +34,7 @@ class redis::config {
       pid_file            => $::redis::pid_file,
       log_file            => $::redis::log_file,
       manage_service_file => $::redis::manage_service_file,
+      workdir             => $::redis::workdir,
     }
   }
 

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -188,20 +188,22 @@ define redis::instance(
   $unixsocket                    = $::redis::unixsocket,
   $unixsocketperm                = $::redis::unixsocketperm,
   $ulimit                        = $::redis::ulimit,
+  $workdir_mode                  = $::redis::workdir_mode,
   $zset_max_ziplist_entries      = $::redis::zset_max_ziplist_entries,
   $zset_max_ziplist_value        = $::redis::zset_max_ziplist_value,
   $cluster_enabled               = $::redis::cluster_enabled,
   $cluster_config_file           = $::redis::cluster_config_file,
   $cluster_node_timeout          = $::redis::cluster_node_timeout,
-  $workdir                       = $::redis::workdir,
   $service_ensure                = $::redis::service_ensure,
   $service_enable                = $::redis::service_enable,
+  $service_group                 = $::redis::service_group,
   $service_hasrestart            = $::redis::service_hasrestart,
   $service_hasstatus             = $::redis::service_hasstatus,
   # Defaults for redis::instance
   $manage_service_file           = true,
   $log_file                      = "/var/log/redis/redis-server-${name}.log",
   $pid_file                      = "/var/run/redis/redis-server-${name}.pid",
+  $workdir                       = "${::redis::workdir}/redis-server-${name}",
 ) {
 
   if $title == 'default' {
@@ -211,6 +213,15 @@ define redis::instance(
     $redis_config_extension    = ".${title}"
     $redis_file_name_orig      = "${config_file_orig}${redis_config_extension}"
     $redis_file_name           = "${config_file}${redis_config_extension}"
+  }
+
+  if $workdir != $::redis::workdir {
+    file { $workdir:
+      ensure => directory,
+      group  => $service_group,
+      mode   => $workdir_mode,
+      owner  => $service_user,
+    }
   }
 
   if $manage_service_file {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -128,7 +128,7 @@ class redis::params {
       $service_name              = 'redis-server'
       $service_user              = 'redis'
       $ppa_repo                  = 'ppa:chris-lea/redis-server'
-      $workdir                   = '/var/lib/redis/'
+      $workdir                   = '/var/lib/redis'
       $workdir_mode              = '0750'
 
       case $::operatingsystem {
@@ -187,7 +187,7 @@ class redis::params {
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
-      $workdir                   = '/var/lib/redis/'
+      $workdir                   = '/var/lib/redis'
       $workdir_mode              = '0755'
 
       case $::operatingsystemmajrelease {
@@ -237,7 +237,7 @@ class redis::params {
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
-      $workdir                   = '/var/db/redis/'
+      $workdir                   = '/var/db/redis'
       $workdir_mode              = '0750'
 
       # pkg version
@@ -271,7 +271,7 @@ class redis::params {
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
-      $workdir                   = '/var/lib/redis/'
+      $workdir                   = '/var/lib/redis'
       $workdir_mode              = '0750'
 
       # suse package version
@@ -306,7 +306,7 @@ class redis::params {
       $service_name              = 'redis'
       $service_user              = 'redis'
       $ppa_repo                  = undef
-      $workdir                   = '/var/lib/redis/'
+      $workdir                   = '/var/lib/redis'
       $workdir_mode              = '0750'
 
       # pkg version

--- a/spec/classes/redis_freebsd_spec.rb
+++ b/spec/classes/redis_freebsd_spec.rb
@@ -7,7 +7,7 @@ describe 'redis' do
     }
 
     context 'should set FreeBSD specific values' do
-      it { should contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /dir \/var\/db\/redis\//) }
+      it { should contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /dir \/var\/db\/redis/) }
       it { should contain_file('/usr/local/etc/redis.conf.puppet').with('content' => /pidfile \/var\/run\/redis\/redis.pid/) }
     end
   end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -16,7 +16,7 @@ describe 'redis::instance', :type => :define do
           ubuntu_1404_facts
         }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-	it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis.conf.redis2/) }
         it { should contain_file('/etc/init.d/redis2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-redis2.pid/) }
@@ -28,7 +28,7 @@ describe 'redis::instance', :type => :define do
           })
         }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-	it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis.conf.redis2/) }
       end
@@ -39,7 +39,7 @@ describe 'redis::instance', :type => :define do
           centos_6_facts
         }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-	it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/REDIS_CONFIG="\/etc\/redis.conf.redis2"/) }
         it { should contain_file('/etc/init.d/redis2').with_content(/pidfile="\/var\/run\/redis\/redis-server-redis2.pid"/) }
@@ -51,7 +51,7 @@ describe 'redis::instance', :type => :define do
           })
         }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-	it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis.conf.redis2/) }
       end

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -17,6 +17,8 @@ describe 'redis::instance', :type => :define do
         }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis.conf.redis2/) }
         it { should contain_file('/etc/init.d/redis2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-redis2.pid/) }
@@ -29,6 +31,8 @@ describe 'redis::instance', :type => :define do
         }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis.conf.redis2/) }
       end
@@ -40,6 +44,8 @@ describe 'redis::instance', :type => :define do
         }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/REDIS_CONFIG="\/etc\/redis.conf.redis2"/) }
         it { should contain_file('/etc/init.d/redis2').with_content(/pidfile="\/var\/run\/redis\/redis-server-redis2.pid"/) }
@@ -52,6 +58,8 @@ describe 'redis::instance', :type => :define do
         }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
+        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis.conf.redis2/) }
       end


### PR DESCRIPTION
Make sure that each Redis instance uses a separate workdir.
This avoids instances overwriting files of other instances.