### PR TITLE
Split Redis instance socket files

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -34,6 +34,7 @@ class redis::config {
       pid_file            => $::redis::pid_file,
       log_file            => $::redis::log_file,
       manage_service_file => $::redis::manage_service_file,
+      unixsocket          => $::redis::unixsocket,
       workdir             => $::redis::workdir,
     }
   }

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -185,7 +185,6 @@ define redis::instance(
   $tcp_backlog                   = $::redis::tcp_backlog,
   $tcp_keepalive                 = $::redis::tcp_keepalive,
   $timeout                       = $::redis::timeout,
-  $unixsocket                    = $::redis::unixsocket,
   $unixsocketperm                = $::redis::unixsocketperm,
   $ulimit                        = $::redis::ulimit,
   $workdir_mode                  = $::redis::workdir_mode,
@@ -203,6 +202,7 @@ define redis::instance(
   $manage_service_file           = true,
   $log_file                      = "/var/log/redis/redis-server-${name}.log",
   $pid_file                      = "/var/run/redis/redis-server-${name}.pid",
+  $unixsocket                    = "/var/run/redis/redis-server-${name}.sock",
   $workdir                       = "${::redis::workdir}/redis-server-${name}",
 ) {
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -18,6 +18,7 @@ describe 'redis::instance', :type => :define do
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
         it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis.conf.redis2/) }
@@ -32,6 +33,7 @@ describe 'redis::instance', :type => :define do
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
         it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis.conf.redis2/) }
@@ -45,6 +47,7 @@ describe 'redis::instance', :type => :define do
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
         it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/init.d/redis2').with_content(/REDIS_CONFIG="\/etc\/redis.conf.redis2"/) }
@@ -59,6 +62,7 @@ describe 'redis::instance', :type => :define do
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
         it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
+        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
         it { should contain_file('/var/lib/redis/redis-server-redis2') }
         it { should contain_service('redis2').with_ensure('running') }
         it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis.conf.redis2/) }


### PR DESCRIPTION
Define separate socket files for the Redis instances by default.
