### PR TITLE
Instance service improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes" ORDERING="random"
   - sudo: required
     dist: trusty
-    rvm: 2.1.9
+    rvm: 2.2.2
     env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES="yes" ORDERING="random"
   - sudo: required
     dist: trusty

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -63,6 +63,7 @@
 # @param [String] save_db_to_disk_interval    save the dataset every N seconds if there are at least M changes in the dataset
 # @param [String] service_enable   Enable/disable daemon at boot.
 # @param [String] service_ensure   Specify if the server should be running.
+# @param [String] service_group   Specify which group to run as.
 # @param [String] service_hasrestart   Does the init script support restart?
 # @param [String] service_hasstatus   Does the init script support status?
 # @param [String] service_user   Specify which user to run as.
@@ -110,6 +111,7 @@
 # @param [String] workdir   The DB will be written inside this directory, with the filename specified
 #   above using the 'dbfilename' configuration directive.
 #   Default: /var/lib/redis/
+# @param [String] workdir_mode   Adjust mode for data directory.
 # @param [String] zset_max_ziplist_entries   Set max entries for sorted sets.
 # @param [String] zset_max_ziplist_value   Set max values for sorted sets.
 # @param [String] cluster_enabled   Enables redis 3.0 cluster functionality

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -216,9 +216,9 @@ define redis::instance(
     $redis_file_name_orig = $config_file_orig
     $redis_file_name      = $config_file
   } else {
-    $redis_server_name         = "redis-server-${name}"
-    $redis_file_name_orig      = sprintf('%s/%s.%s', dirname($config_file_orig), $redis_server_name, 'conf.puppet')
-    $redis_file_name           = sprintf('%s/%s.%s', dirname($config_file), $redis_server_name, 'conf')
+    $redis_server_name    = "redis-server-${name}"
+    $redis_file_name_orig = sprintf('%s/%s.%s', dirname($config_file_orig), $redis_server_name, 'conf.puppet')
+    $redis_file_name      = sprintf('%s/%s.%s', dirname($config_file), $redis_server_name, 'conf')
   }
 
   if $log_dir != $::redis::log_dir {
@@ -249,7 +249,7 @@ define redis::instance(
 
     if $service_provider_lookup == 'systemd' {
 
-      file { "/etc/systemd/system/${title}.service":
+      file { "/etc/systemd/system/${redis_server_name}.service":
         ensure  => file,
         owner   => 'root',
         group   => 'root',
@@ -259,13 +259,13 @@ define redis::instance(
       ~> Exec['systemd-reload-redis']
 
       if $title != 'default' {
-        service { $title:
+        service { $redis_server_name:
           ensure     => $service_ensure,
           enable     => $service_enable,
           hasrestart => $service_hasrestart,
           hasstatus  => $service_hasstatus,
           subscribe  => [
-            File["/etc/systemd/system/${title}.service"],
+            File["/etc/systemd/system/${redis_server_name}.service"],
             Exec["cp -p ${redis_file_name_orig} ${redis_file_name}"],
           ],
         }
@@ -273,20 +273,20 @@ define redis::instance(
 
     } else {
 
-      file { "/etc/init.d/${title}":
+      file { "/etc/init.d/${redis_server_name}":
         ensure  => file,
         mode    => '0755',
         content => template("redis/service_templates/redis.${::osfamily}.erb"),
       }
 
       if $title != 'default' {
-        service { $title:
+        service { $redis_server_name:
           ensure     => $service_ensure,
           enable     => $service_enable,
           hasrestart => $service_hasrestart,
           hasstatus  => $service_hasstatus,
           subscribe  => [
-            File["/etc/init.d/${title}"],
+            File["/etc/init.d/${redis_server_name}"],
             Exec["cp -p ${redis_file_name_orig} ${redis_file_name}"],
           ],
         }

--- a/spec/acceptance/redis_multi_instances_one_host_spec.rb
+++ b/spec/acceptance/redis_multi_instances_one_host_spec.rb
@@ -4,12 +4,12 @@ require 'spec_helper_acceptance'
 describe 'redis::instance', :unless => (fact('operatingsystem') == 'Debian') do
   case fact('osfamily')
   when 'Debian'
-    config_path  = '/etc/redis/redis.conf'
+    config_path  = '/etc/redis'
     manage_repo  = false
     redis_name = 'redis-server'
   else
     redis_name = 'redis'
-    config_path  = '/etc/redis.conf'
+    config_path  = '/etc'
     manage_repo  = true
   end
 
@@ -43,19 +43,19 @@ describe 'redis::instance', :unless => (fact('operatingsystem') == 'Debian') do
     it { should be_installed }
   end
 
-  describe service('redis1') do
+  describe service('redis-server-redis1') do
     it { should be_running }
   end
 
-  describe service('redis2') do
+  describe service('redis-server-redis2') do
     it { should be_running }
   end
 
-  describe file("#{config_path}.redis1") do
+  describe file("#{config_path}/redis-server-redis1.conf") do
     its(:content) { should match /port 7777/ }
   end
 
-  describe file("#{config_path}.redis2") do
+  describe file("#{config_path}/redis-server-redis2.conf") do
     its(:content) { should match /port 8888/ }
   end
 

--- a/spec/defines/instance_spec.rb
+++ b/spec/defines/instance_spec.rb
@@ -7,7 +7,7 @@ describe 'redis::instance', :type => :define do
     }'
   end
   let :title do
-    'redis2'
+    'app2'
   end
   describe 'os-dependent items' do
     context "on Ubuntu systems" do
@@ -15,15 +15,15 @@ describe 'redis::instance', :type => :define do
         let(:facts) {
           ubuntu_1404_facts
         }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-redis2') }
-        it { should contain_service('redis2').with_ensure('running') }
-        it { should contain_service('redis2').with_enable('true') }
-        it { should contain_file('/etc/init.d/redis2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis.conf.redis2/) }
-        it { should contain_file('/etc/init.d/redis2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-redis2.pid/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { should contain_file('/var/lib/redis/redis-server-app2') }
+        it { should contain_service('redis-server-app2').with_ensure('running') }
+        it { should contain_service('redis-server-app2').with_enable('true') }
+        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/DAEMON_ARGS=\/etc\/redis\/redis-server-app2.conf/) }
+        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/PIDFILE=\/var\/run\/redis\/redis-server-app2.pid/) }
       end
       context '16.04' do
         let(:facts) {
@@ -31,14 +31,14 @@ describe 'redis::instance', :type => :define do
             :service_provider => 'systemd',
           })
         }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
-        it { should contain_file('/etc/redis/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-redis2') }
-        it { should contain_service('redis2').with_ensure('running') }
-        it { should contain_service('redis2').with_enable('true') }
-        it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis.conf.redis2/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { should contain_file('/etc/redis/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { should contain_file('/var/lib/redis/redis-server-app2') }
+        it { should contain_service('redis-server-app2').with_ensure('running') }
+        it { should contain_service('redis-server-app2').with_enable('true') }
+        it { should contain_file('/etc/systemd/system/redis-server-app2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis\/redis-server-app2.conf/) }
       end
     end
     context "on CentOS systems" do
@@ -46,15 +46,15 @@ describe 'redis::instance', :type => :define do
         let(:facts) {
           centos_6_facts
         }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-redis2') }
-        it { should contain_service('redis2').with_ensure('running') }
-        it { should contain_service('redis2').with_enable('true') }
-        it { should contain_file('/etc/init.d/redis2').with_content(/REDIS_CONFIG="\/etc\/redis.conf.redis2"/) }
-        it { should contain_file('/etc/init.d/redis2').with_content(/pidfile="\/var\/run\/redis\/redis-server-redis2.pid"/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { should contain_file('/var/lib/redis/redis-server-app2') }
+        it { should contain_service('redis-server-app2').with_ensure('running') }
+        it { should contain_service('redis-server-app2').with_enable('true') }
+        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/REDIS_CONFIG="\/etc\/redis-server-app2.conf"/) }
+        it { should contain_file('/etc/init.d/redis-server-app2').with_content(/pidfile="\/var\/run\/redis\/redis-server-app2.pid"/) }
       end
       context '7' do
         let(:facts) {
@@ -62,14 +62,14 @@ describe 'redis::instance', :type => :define do
             :service_provider => 'systemd',
           })
         }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^bind 127.0.0.1/) }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^logfile \/var\/log\/redis\/redis-server-redis2.log/) }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^dir \/var\/lib\/redis\/redis-server-redis2/) }
-        it { should contain_file('/etc/redis.conf.puppet.redis2').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-redis2.sock/) }
-        it { should contain_file('/var/lib/redis/redis-server-redis2') }
-        it { should contain_service('redis2').with_ensure('running') }
-        it { should contain_service('redis2').with_enable('true') }
-        it { should contain_file('/etc/systemd/system/redis2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis.conf.redis2/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^bind 127.0.0.1/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^logfile \/var\/log\/redis\/redis-server-app2.log/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^dir \/var\/lib\/redis\/redis-server-app2/) }
+        it { should contain_file('/etc/redis-server-app2.conf.puppet').with('content' => /^unixsocket \/var\/run\/redis\/redis-server-app2.sock/) }
+        it { should contain_file('/var/lib/redis/redis-server-app2') }
+        it { should contain_service('redis-server-app2').with_ensure('running') }
+        it { should contain_service('redis-server-app2').with_enable('true') }
+        it { should contain_file('/etc/systemd/system/redis-server-app2.service').with_content(/ExecStart=\/usr\/bin\/redis-server \/etc\/redis-server-app2.conf/) }
       end
     end
   end

--- a/templates/redis.conf.2.4.10.erb
+++ b/templates/redis.conf.2.4.10.erb
@@ -51,7 +51,7 @@ loglevel <%= @log_level %>
 # Specify the log file name. Also 'stdout' can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile <%= @log_file %>
+logfile <%= @_real_log_file %>
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.

--- a/templates/redis.conf.2.8.erb
+++ b/templates/redis.conf.2.8.erb
@@ -113,7 +113,7 @@ loglevel <%= @log_level %>
 # Specify the log file name. Also the empty string can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile <%= @log_file %>
+logfile <%= @_real_log_file %>
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -75,7 +75,7 @@ loglevel <%= @log_level %>
 # Specify the log file name. Also 'stdout' can be used to force
 # Redis to log on the standard output. Note that if you use standard
 # output for logging but daemonize, logs will be sent to /dev/null
-logfile <%= @log_file %>
+logfile <%= @_real_log_file %>
 
 # To enable logging to the system logger, just set 'syslog-enabled' to yes,
 # and optionally update the other syslog parameters to suit your needs.


### PR DESCRIPTION
Some small fixes to align manifest documentation and file path inheritance

The last commit reworks the naming convention for non default instances:
- makes sure the config file name ends on .conf(.puppet) instead of the instance name.
- include redis in the service name

The service name could be useful for people running multiple apps on the same server with for example dedicated JBoss and Redis instances.
In this way they could have a service jboss-server-app1 and redis-server-app1 instead of a non ambiguous service app1

We could drop the -server part to shorten the names if required.

