### PR TITLE
Fix issues with missing locale for Debian box

### DIFF
--- a/spec/acceptance/nodesets/debian-8-docker.yml
+++ b/spec/acceptance/nodesets/debian-8-docker.yml
@@ -9,8 +9,7 @@ HOSTS:
     docker_preserve_image: true
     docker_image_commands:
       - apt-get install -yq wget net-tools locales apt-transport-https software-properties-common
-      - locale-gen en en_US en_US.UTF-8
-      - dpkg-reconfigure locales
+      - echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && DEBIAN_FRONTEND=noninteractive locale-gen en_US.UTF-8 && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && DEBIAN_FRONTEND=noninteractive /usr/sbin/update-locale LANG=en_US.UTF-8
       - rm /lib/systemd/system/systemd*udev*
       - rm /lib/systemd/system/getty.target
 CONFIG:


### PR DESCRIPTION
* Output no longer contains `bash: warning: setlocale: LC_ALL: cannot change locale (en_US.UTF-8)`