### PR TITLE
Added configuration options for client-output-buffer-limit

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -143,6 +143,8 @@ class redis (
   $auto_aof_rewrite_min_size     = $::redis::params::auto_aof_rewrite_min_size,
   $auto_aof_rewrite_percentage   = $::redis::params::auto_aof_rewrite_percentage,
   $bind                          = $::redis::params::bind,
+  $output_buffer_limit_slave     = $::redis::params::output_buffer_limit_slave,
+  $output_buffer_limit_pubsub    = $::redis::params::output_buffer_limit_pubsub,
   $conf_template                 = $::redis::params::conf_template,
   $config_dir                    = $::redis::params::config_dir,
   $config_dir_mode               = $::redis::params::config_dir_mode,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -129,6 +129,8 @@ define redis::instance(
   $auto_aof_rewrite_min_size     = $::redis::auto_aof_rewrite_min_size,
   $auto_aof_rewrite_percentage   = $::redis::auto_aof_rewrite_percentage,
   $bind                          = $::redis::bind,
+  $output_buffer_limit_slave     = $::redis::output_buffer_limit_slave,
+  $output_buffer_limit_pubsub    = $::redis::output_buffer_limit_pubsub,
   $conf_template                 = $::redis::conf_template,
   $config_dir                    = $::redis::config_dir,
   $config_dir_mode               = $::redis::config_dir_mode,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,8 @@ class redis::params {
   $auto_aof_rewrite_min_size       = '64mb'
   $auto_aof_rewrite_percentage     = 100
   $bind                            = '127.0.0.1'
+  $output_buffer_limit_slave       = '256mb 64mb 60'
+  $output_buffer_limit_pubsub      = '32mb 8mb 60'
   $conf_template                   = 'redis/redis.conf.erb'
   $default_install                 = true
   $databases                       = 16

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -156,6 +156,26 @@ describe 'redis', :type => :class do
         it { is_expected.to contain_file(config_file_orig).with_content(/bind.*_VALUE_/) }
       end
 
+      describe 'with parameter output_buffer_limit_slave' do
+        let (:params) {
+          {
+              :output_buffer_limit_slave => '_VALUE_'
+          }
+        }
+
+        it { is_expected.to contain_file(config_file_orig).with_content(/client-output-buffer-limit slave.*_VALUE_/) }
+      end
+
+      describe 'with parameter output_buffer_limit_pubsub' do
+        let (:params) {
+          {
+              :output_buffer_limit_pubsub => '_VALUE_'
+          }
+        }
+
+        it { is_expected.to contain_file(config_file_orig).with_content(/client-output-buffer-limit pubsub.*_VALUE_/) }
+      end
+
       describe 'with parameter: config_dir' do
         let (:params) { { :config_dir => '_VALUE_' } }
 

--- a/templates/redis.conf.2.8.erb
+++ b/templates/redis.conf.2.8.erb
@@ -713,8 +713,8 @@ activerehashing <% if @activerehashing -%>yes<% else -%>no<% end -%>
 #
 # Both the hard or the soft limit can be disabled by setting them to zero.
 client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit slave 256mb 64mb 60
-client-output-buffer-limit pubsub 32mb 8mb 60
+client-output-buffer-limit slave <%= @output_buffer_limit_slave %>
+client-output-buffer-limit pubsub <%= @output_buffer_limit_pubsub %>
 
 # Redis calls an internal function to perform many background tasks, like
 # closing connections of clients in timeout, purging expired keys that are

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -720,8 +720,8 @@ activerehashing <% if @activerehashing -%>yes<% else -%>no<% end -%>
 #
 # Both the hard or the soft limit can be disabled just setting it to zero.
 client-output-buffer-limit normal 0 0 0
-client-output-buffer-limit slave 256mb 64mb 60
-client-output-buffer-limit pubsub 32mb 8mb 60
+client-output-buffer-limit slave <%= @output_buffer_limit_slave %>
+client-output-buffer-limit pubsub <%= @output_buffer_limit_pubsub %>
 
 # Redis calls an internal function to perform many background tasks, like
 # closing connections of clients in timeout, purging expired keys that are


### PR DESCRIPTION
The configuration for client-output-buffer-limit slave and pubsub can now be configured.