### PR TITLE
Pin version of redis gem

### DIFF
--- a/spec/acceptance/redisget_spec.rb
+++ b/spec/acceptance/redisget_spec.rb
@@ -13,7 +13,7 @@ describe 'redisget() function' do
     }
 
     package { 'redis-rubygem' :
-      ensure   => installed,
+      ensure   => '3.3.3',
       name     => 'redis',
       provider => 'puppet_gem',
     }


### PR DESCRIPTION
```
  Error: Execution of '/opt/puppetlabs/puppet/bin/gem install --no-rdoc --no-ri redis' returned 1: ERROR:  Error installing redis:
  	redis requires Ruby version >= 2.2.2.
```

As seen in https://github.com/arioch/puppet-redis/pull/230