### PR TITLE
Updates for EL6

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -43,6 +43,26 @@ class redis::config {
     contain ::redis::ulimit
   }
 
+  $service_provider_lookup = pick(getvar_emptystring('service_provider'), false)
+
+  if $service_provider_lookup != 'systemd' {
+    case $::operatingsystem {
+      'Debian': {
+        $var_run_redis_mode = '2775'
+      }
+      default: {
+        $var_run_redis_mode = '0755'
+      }
+    }
+
+    file { '/var/run/redis':
+      ensure => 'directory',
+      owner  => $::redis::config_owner,
+      group  => $::redis::config_group,
+      mode   => $var_run_redis_mode,
+    }
+  }
+
   # Adjust /etc/default/redis-server on Debian systems
   case $::osfamily {
     'Debian': {
@@ -52,27 +72,6 @@ class redis::config {
         mode   => $::redis::config_file_mode,
         owner  => $::redis::config_owner,
       }
-
-      $service_provider_lookup = pick(getvar_emptystring('service_provider'), false)
-
-      if $service_provider_lookup != 'systemd' {
-        case $::operatingsystem {
-          'Debian': {
-            $var_run_redis_mode = '2775'
-          }
-          default: {
-            $var_run_redis_mode = '0755'
-          }
-        }
-
-        file { '/var/run/redis':
-          ensure => 'directory',
-          owner  => $::redis::config_owner,
-          group  => $::redis::config_group,
-          mode   => $var_run_redis_mode,
-        }
-      }
-
     }
 
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -194,8 +194,9 @@ class redis::params {
 
       case $::operatingsystemmajrelease {
         '6': {
-          # CentOS 6 EPEL package is 2.4.10
-          $minimum_version           = '2.4.10'
+          # CentOS 6 EPEL package is just updated to 3.2.10
+          # https://bugzilla.redhat.com/show_bug.cgi?id=923970
+          $minimum_version           = '3.2.10'
 
           $service_group             = 'root'
         }

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -9,21 +9,6 @@ describe 'redis' do
 
     context 'should set CentOS specific values' do
 
-      context 'when $::redis_server_version fact is not present (older features not enabled)' do
-
-        let(:facts) {
-          centos_6_facts.merge({
-            :redis_server_version => nil,
-            :puppetversion        => Puppet.version,
-          })
-        }
-
-        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-zipmap-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-ziplist-entries/) }
-        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^tcp-backlog/) }
-
-      end
-
       context 'when $::redis_server_version fact is not present and package_ensure is a newer version(3.2.1) (older features enabled)' do
 
         let(:facts) {

--- a/templates/service_templates/redis.RedHat.erb
+++ b/templates/service_templates/redis.RedHat.erb
@@ -17,7 +17,7 @@
 . /etc/rc.d/init.d/functions
 
 name="redis-server-<%= @name %>"
-exec="/usr/sbin/redis-server"
+exec="/usr/bin/redis-server"
 pidfile="/var/run/redis/redis-server-<%= @name %>.pid"
 REDIS_CONFIG="<%= @redis_file_name %>"
 


### PR DESCRIPTION
* EPEL 6 version of Redis just jumped from 2.8 to 3.2, different location for starting binary
* Also update the template version
* Move /var/run directory into config
* https://bugzilla.redhat.com/show_bug.cgi?id=923970