### PR TITLE
protected-mode configuration option (Redis 3.2+)

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -59,6 +59,7 @@
 # @param [String] package_name   Upstream package name.
 # @param [String] pid_file   Where to store the pid.
 # @param [String] port   Configure which port to listen on.
+# @param [String] protected_mode  Whether protected mode is enabled or not.  Only applicable when no bind is set.
 # @param [String] ppa_repo   Specify upstream (Ubuntu) PPA entry.
 # @param [String] rdbcompression   Enable/disable compression of string objects using LZF when dumping.
 # @param [String] repl_backlog_size   The replication backlog size
@@ -186,6 +187,7 @@ class redis (
   $package_name                  = $::redis::params::package_name,
   $pid_file                      = $::redis::params::pid_file,
   $port                          = $::redis::params::port,
+  $protected_mode                = $::redis::params::protected_mode,
   $ppa_repo                      = $::redis::params::ppa_repo,
   $rdbcompression                = $::redis::params::rdbcompression,
   $repl_backlog_size             = $::redis::params::repl_backlog_size,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -53,6 +53,7 @@
 # @param [String] notify_keyspace_events   Which events to notify Pub/Sub clients about events happening
 # @param [String] pid_file   Where to store the pid.
 # @param [String] port   Configure which port to listen on.
+# @param [String] protected_mode  Whether protected mode is enabled or not.  Only applicable when no bind is set.
 # @param [String] rdbcompression   Enable/disable compression of string objects using LZF when dumping.
 # @param [String] repl_backlog_size   The replication backlog size
 # @param [String] repl_backlog_ttl   The number of seconds to elapse before freeing backlog buffer
@@ -170,6 +171,7 @@ define redis::instance(
   $managed_by_cluster_manager    = $::redis::managed_by_cluster_manager,
   $package_ensure                = $::redis::package_ensure,
   $port                          = $::redis::port,
+  $protected_mode                = $::redis::protected_mode,
   $rdbcompression                = $::redis::rdbcompression,
   $repl_backlog_size             = $::redis::repl_backlog_size,
   $repl_backlog_ttl              = $::redis::repl_backlog_ttl,

--- a/manifests/instance.pp
+++ b/manifests/instance.pp
@@ -333,6 +333,9 @@ define redis::instance(
       /^2.8./: {
         File[$redis_file_name_orig] { content => template('redis/redis.conf.2.8.erb') }
       }
+      /^3.2./: {
+        File[$redis_file_name_orig] { content => template('redis/redis.conf.3.2.erb') }
+      }
       default: {
         File[$redis_file_name_orig] { content => template($conf_template) }
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -44,6 +44,7 @@ class redis::params {
   $notify_keyspace_events          = undef
   $notify_service                  = true
   $port                            = 6379
+  $protected_mode                  = 'yes'
   $rdbcompression                  = true
   $requirepass                     = undef
   $save_db_to_disk                 = true

--- a/spec/classes/redis_centos_6_spec.rb
+++ b/spec/classes/redis_centos_6_spec.rb
@@ -21,6 +21,7 @@ describe 'redis' do
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
 
@@ -36,6 +37,7 @@ describe 'redis' do
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
       end
 
@@ -50,6 +52,7 @@ describe 'redis' do
 
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').without('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^tcp-backlog/) }
 
       end
@@ -65,6 +68,7 @@ describe 'redis' do
 
         it { should contain_file('/etc/redis.conf.puppet').without('content' => /^hash-max-zipmap-entries/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis.conf.puppet').with('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis.conf.puppet').with('content' => /^tcp-backlog/) }
 
       end

--- a/spec/classes/redis_spec.rb
+++ b/spec/classes/redis_spec.rb
@@ -592,6 +592,19 @@ describe 'redis', :type => :class do
         }
       end
 
+      describe 'with parameter protected-mode' do
+              let (:params) {
+                {
+                  :protected_mode => '_VALUE_'
+                }
+              }
+
+              it { is_expected.to contain_file(config_file_orig).with(
+                  'content' => /protected-mode.*_VALUE_/
+                )
+              }
+            end
+
       describe 'with parameter hll_sparse_max_bytes' do
         let (:params) {
           {

--- a/spec/classes/redis_ubuntu_1404_spec.rb
+++ b/spec/classes/redis_ubuntu_1404_spec.rb
@@ -19,6 +19,7 @@ describe 'redis' do
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
 
       end
 
@@ -32,6 +33,7 @@ describe 'redis' do
         let (:params) { { :package_ensure => '3.2.1' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
 
       end
@@ -46,6 +48,7 @@ describe 'redis' do
         let (:params) { { :package_ensure => '3:3.2.1' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
 
       end
@@ -60,6 +63,7 @@ describe 'redis' do
         let (:params) { { :package_ensure => '4:4.0-rc3' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
 
       end
@@ -73,6 +77,7 @@ describe 'redis' do
         let (:params) { { :package_ensure => '4.0-rc3' } }
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
 
       end
@@ -87,6 +92,7 @@ describe 'redis' do
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^tcp-backlog/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').without('content' => /^protected-mode/) }
 
       end
 
@@ -100,6 +106,7 @@ describe 'redis' do
 
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^hash-max-ziplist-entries/) }
         it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^tcp-backlog/) }
+        it { should contain_file('/etc/redis/redis.conf.puppet').with('content' => /^protected-mode/) }
 
       end
     end

--- a/spec/fixtures/facts/redis_server_3209_version
+++ b/spec/fixtures/facts/redis_server_3209_version
@@ -1,0 +1,1 @@
+Redis server v=3.2.9 sha=00000000:0 malloc=jemalloc-4.0.3 bits=64 build=67e0f9d6580364c0

--- a/spec/unit/redis_server_version_spec.rb
+++ b/spec/unit/redis_server_version_spec.rb
@@ -18,6 +18,13 @@ describe 'redis_server_version', type: :fact do
     expect(Facter.fact(:redis_server_version).value).to eq('2.8.19')
   end
 
+  it 'is 3.2.9 according to output' do
+    Facter::Util::Resolution.stubs(:which).with('redis-server').returns('/usr/bin/redis-server')
+    redis_server_3209_version = File.read(fixtures('facts', 'redis_server_3209_version'))
+    Facter::Util::Resolution.stubs(:exec).with('redis-server -v').returns(redis_server_3209_version)
+    expect(Facter.fact(:redis_server_version).value).to eq('3.2.9')
+  end
+
   it 'is empty string if redis-server not installed' do
     Facter::Util::Resolution.stubs(:which).with('redis-server').returns(nil)
     expect(Facter.fact(:redis_server_version).value).to eq(nil)

--- a/templates/redis.conf.3.2.erb
+++ b/templates/redis.conf.3.2.erb
@@ -20,6 +20,25 @@ daemonize <% if @daemonize -%>yes<% else -%>no<% end -%>
 # default. You can specify a custom pid file location here.
 pidfile <%= @pid_file %>
 
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+protected-mode <%= @protected_mode %>
+
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.
 port <%= @port %>

--- a/templates/redis.conf.erb
+++ b/templates/redis.conf.erb
@@ -20,6 +20,25 @@ daemonize <% if @daemonize -%>yes<% else -%>no<% end -%>
 # default. You can specify a custom pid file location here.
 pidfile <%= @pid_file %>
 
+# Protected mode is a layer of security protection, in order to avoid that
+# Redis instances left open on the internet are accessed and exploited.
+#
+# When protected mode is on and if:
+#
+# 1) The server is not binding explicitly to a set of addresses using the
+#    "bind" directive.
+# 2) No password is configured.
+#
+# The server only accepts connections from clients connecting from the
+# IPv4 and IPv6 loopback addresses 127.0.0.1 and ::1, and from Unix domain
+# sockets.
+#
+# By default protected mode is enabled. You should disable it only if
+# you are sure you want clients from other hosts to connect to Redis
+# even if no authentication is configured, nor a specific set of interfaces
+# are explicitly listed using the "bind" directive.
+protected-mode <%= @protected_mode %>
+
 # Accept connections on the specified port, default is 6379.
 # If port 0 is specified Redis will not listen on a TCP socket.
 port <%= @port %>


### PR DESCRIPTION
This allows one to bypass the protected-mode on Redis 3.2+ when listening on all interfaces.