### PR TITLE
Update redis mode on wheezy

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,7 +48,11 @@ class redis::config {
   if $service_provider_lookup != 'systemd' {
     case $::operatingsystem {
       'Debian': {
-        $var_run_redis_mode = '2775'
+        if $::lsbdistcodename == 'wheezy' {
+          $var_run_redis_mode = '2755'
+        } else {
+          $var_run_redis_mode = '2775'
+        }
       }
       default: {
         $var_run_redis_mode = '0755'


### PR DESCRIPTION
This commit updates the mode for redis run directory on Debian platforms without systemd. Without this change puppet will attempt to change the mode on /var/run/redis during every puppet run, which triggers a refresh.