### PR TITLE
Update redis mode on wheezy

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -48,17 +48,24 @@ class redis::config {
   if $service_provider_lookup != 'systemd' {
     case $::operatingsystem {
       'Debian': {
-        $var_run_redis_mode = '2775'
+        if $::lsbdistcodename == 'wheezy' {
+          $var_run_redis_mode  = '2755'
+          $var_run_redis_group = 'redis'
+        } else {
+          $var_run_redis_group = $::redis::config_group
+          $var_run_redis_mode = '2775'
+        }
       }
       default: {
         $var_run_redis_mode = '0755'
+        $var_run_redis_group = $::redis::config_group
       }
     }
 
     file { '/var/run/redis':
       ensure => 'directory',
       owner  => $::redis::config_owner,
-      group  => $::redis::config_group,
+      group  => $var_run_redis_group,
       mode   => $var_run_redis_mode,
     }
   }

--- a/spec/acceptance/nodesets/debian-7-docker.yml
+++ b/spec/acceptance/nodesets/debian-7-docker.yml
@@ -9,8 +9,7 @@ HOSTS:
     docker_preserve_image: true
     docker_image_commands:
       - apt-get install -yq wget libssl-dev net-tools locales apt-transport-https software-properties-common
-      - locale-gen en en_US en_US.UTF-8
-      - dpkg-reconfigure locales
+      - echo "en_US.UTF-8 UTF-8" > /etc/locale.gen && DEBIAN_FRONTEND=noninteractive locale-gen en_US.UTF-8 && DEBIAN_FRONTEND=noninteractive dpkg-reconfigure locales && DEBIAN_FRONTEND=noninteractive /usr/sbin/update-locale LANG=en_US.UTF-8
 CONFIG:
   type: foss
   log_level: debug

--- a/spec/classes/redis_debian_wheezy_spec.rb
+++ b/spec/classes/redis_debian_wheezy_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe 'redis' do
+  context 'on Debian Wheezy' do
+
+    let(:facts) {
+      debian_wheezy_facts
+    }
+
+    context 'should set Wheezy specific values' do
+
+      context 'should set redis rundir correctly to Wheezy requirements' do
+        it { should contain_file('/var/run/redis').with('mode' => '2755') }
+        it { should contain_file('/var/run/redis').with('group' => 'redis') }
+      end
+    end
+  end
+
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,6 +91,7 @@ def debian_facts
     :osfamily                  => 'Debian',
     :operatingsystemmajrelease => '8',
     :puppetversion             => '4.5.2',
+    :lsbdistcodename           => 'jessie',
   }
 end
 
@@ -120,12 +121,23 @@ def centos_7_facts
   }
 end
 
+def debian_wheezy_facts
+  {
+    :operatingsystem           => 'Debian',
+    :osfamily                  => 'Debian',
+    :operatingsystemmajrelease => '8',
+    :puppetversion             => '4.5.2',
+    :lsbdistcodename           => 'wheezy',
+  }
+end
+
 def ubuntu_1404_facts
   {
     :operatingsystem           => 'Ubuntu',
     :osfamily                  => 'Debian',
     :operatingsystemmajrelease => '14.04',
-    :puppetversion             => '4.5.2'
+    :puppetversion             => '4.5.2',
+    :lsbdistcodename           => 'trusty',
   }
 end
 
@@ -134,7 +146,8 @@ def ubuntu_1604_facts
     :operatingsystem           => 'Ubuntu',
     :osfamily                  => 'Debian',
     :operatingsystemmajrelease => '16.04',
-    :puppetversion             => '4.5.2'
+    :puppetversion             => '4.5.2',
+    :lsbdistcodename           => 'xenial',
   }
 end
 


### PR DESCRIPTION
* This commit updates the mode for redis run directory on Debian platforms without systemd. * Without this change puppet will attempt to change the mode on /var/run/redis during every puppet run, which triggers a refresh.

Replaces #250 