### PR TITLE
Adds logic for installing redid-sentinel package

### DIFF
--- a/manifests/sentinel.pp
+++ b/manifests/sentinel.pp
@@ -200,9 +200,13 @@ class redis::sentinel (
 
   if $::osfamily == 'Debian' {
     # Debian flavour machines have a dedicated redis-sentinel package
-    # This is default in Xenial onwards, unstable debian or PPA/other upstream
+    # This is default in Xenial or Stretch onwards or PPA/other upstream
     # See https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=775414 for context
-    if (versioncmp($::operatingsystemmajrelease, '16.04') >= 0 or $::redis::manage_repo) {
+    if (
+      (versioncmp($::operatingsystemmajrelease, '16.04') >= 0 and $::operatingsystem == 'Ubuntu') or
+      (versioncmp($::operatingsystemmajrelease, '9') >= 0 and $::operatingsystem == 'Debian') or
+      $::redis::manage_repo
+      ) {
       package { $package_name:
         ensure => $package_ensure,
       }

--- a/spec/classes/redis_sentinel_spec.rb
+++ b/spec/classes/redis_sentinel_spec.rb
@@ -87,4 +87,26 @@ describe 'redis::sentinel', :type => :class do
     }
   end
 
+  describe 'on Debian Jessie' do
+
+    let (:facts) { debian_facts.merge({
+      :operatingsystemmajrelease => '8',
+    }) }
+
+    it { should create_class('redis::sentinel') }
+
+    it { should_not contain_package('redis-sentinel').with_ensure('present') }
+  end
+
+  describe 'on Debian Stretch' do
+
+    let (:facts) { debian_facts.merge({
+      :operatingsystemmajrelease => '9',
+    }) }
+
+    it { should create_class('redis::sentinel') }
+
+    it { should contain_package('redis-sentinel').with_ensure('present') }
+  end
+
 end


### PR DESCRIPTION
* Debian Stretch also added a separate package 
also: https://packages.debian.org/stretch/redis-sentinel
* Closes #253