### PR TITLE
Fix setting ulimit under systemd

### DIFF
--- a/manifests/ulimit.pp
+++ b/manifests/ulimit.pp
@@ -43,12 +43,12 @@ class redis::ulimit {
       mode   => '0444',
     }
     augeas { 'Systemd redis ulimit' :
-      incl    => "/etc/systemd/system/${::redis::service_name}.service.d/limits.conf",
+      incl    => "/etc/systemd/system/${::redis::service_name}.service.d/limit.conf",
       lens    => 'Systemd.lns',
-      context => "/etc/systemd/system/${::redis::service_name}.service.d/limits.conf",
       changes => [
         "defnode nofile Service/LimitNOFILE \"\"",
-        "set \$nofile/value \"${::redis::ulimit}\""],
+        "set \$nofile/value \"${::redis::ulimit}\""
+        ],
       notify  => [
         Exec['systemd-reload-redis'],
       ],
@@ -73,5 +73,4 @@ class redis::ulimit {
       }
     }
   }
-
 }


### PR DESCRIPTION
1.
There was an inconsistency with creating a file
/etc/systemd/system/redis-server.service.d/limit.conf
but then referring to file
/etc/systemd/system/redis-server.service.d/limits.conf
in the augeas resource.

Whereas limits.conf seems to be a better name the file
limit.conf is now likely to exist on many systems, and
I don't want to risk having both a limit.conf and a
limits.conf. So limit.conf it is.

2.
The context was set to to the filepath, but should have been
prefixed with "/files". Seeing as this is default I removed the context.

This closes  arioch/puppet-redis#268