### PR TITLE
Update puppetlabs/apt dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,7 +8,7 @@
   "project_page": "http://arioch.github.io/puppet-redis/",
   "issues_url": "https://github.com/arioch/puppet-redis/issues",
   "dependencies": [
-    {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <5.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 2.3.0 <6.0.0"},
     {"name":"puppetlabs/stdlib","version_requirement":">= 1.0.2 <5.0.0"},
     {"name":"stahnma/epel","version_requirement":">= 1.2.2 <2.0.0"},
     {

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -7,6 +7,7 @@ def change_root_password
 end
 
 def install_bolt_on(hosts)
+  on(hosts, "/opt/puppetlabs/puppet/bin/gem install winrm-fs -v '1.1.1' --no-ri --no-rdoc", acceptable_exit_codes: [0]).stdout
   on(hosts, "/opt/puppetlabs/puppet/bin/gem install bolt -v '0.5.1' --no-ri --no-rdoc", acceptable_exit_codes: [0]).stdout
 end
 


### PR DESCRIPTION
The puppetlabs/apt version 5 adds fixes for Ubuntu 18.04.