### PR TITLE
Make sure mode for /var/run/redis is also set correctly on Ubuntu

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ class redis::config {
   $service_provider_lookup = pick(getvar('service_provider'), false)
 
   if $service_provider_lookup != 'systemd' {
-    case $::operatingsystem {
+    case $::osfamily {
       'Debian': {
         if $::lsbdistcodename == 'wheezy' {
           $var_run_redis_mode  = '2755'


### PR DESCRIPTION
SSIA mode for /var/run/redis is changed from 2755 to 0755 on each run on Ubuntu