### PR TITLE
fix the restart issue on Ubuntu

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,10 +56,10 @@ class redis::config {
           $var_run_redis_mode = '2775'
         }
       }
-     'Ubuntu': {                                     
-        $var_run_redis_group = $::redis::config_group 
-        $var_run_redis_mode = '2755'                  
-      }                                               
+     'Ubuntu': {
+        $var_run_redis_group = $::redis::config_group
+        $var_run_redis_mode = '2755'
+      }
       default: {
         $var_run_redis_mode = '0755'
         $var_run_redis_group = $::redis::config_group

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -46,7 +46,7 @@ class redis::config {
   $service_provider_lookup = pick(getvar('service_provider'), false)
 
   if $service_provider_lookup != 'systemd' {
-    case $::osfamily {
+    case $::operatingsystem {
       'Debian': {
         if $::lsbdistcodename == 'wheezy' {
           $var_run_redis_mode  = '2755'
@@ -56,6 +56,10 @@ class redis::config {
           $var_run_redis_mode = '2775'
         }
       }
+     'Ubuntu': {                                     
+        $var_run_redis_group = $::redis::config_group 
+        $var_run_redis_mode = '2755'                  
+      }                                               
       default: {
         $var_run_redis_mode = '0755'
         $var_run_redis_group = $::redis::config_group


### PR DESCRIPTION
Ubuntu 18.04 insists on mode 2755, which is different from 2775.